### PR TITLE
Use relative paths in Vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+const resolveFromRoot = (...segments: string[]) => path.resolve(__dirname, ...segments);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@common': resolveFromRoot('packages/common/src'),
+      '@db': resolveFromRoot('packages/db/src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- switch Vitest alias configuration to resolve paths relative to the repo root
- ensure @common and @db aliases use path.resolve to avoid environment-specific absolute paths

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d0a196134483279d3a6065a1d8f7a0