### PR TITLE
Remove redundant program serializer

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono';
+
+export type Program = {
+  id: string;
+  name: string;
+  description: string;
+  url: string;
+  region: string;
+  industries: string[];
+  tags: string[];
+  criteria: string[];
+};
+
+const programs: Program[] = [
+  {
+    id: 'california-small-business-grant',
+    name: 'California Small Business Grant',
+    description:
+      'Provides matching funds for capital investments made by eligible small businesses operating in California.',
+    url: 'https://example.com/programs/california-small-business-grant',
+    region: 'CA',
+    industries: ['Manufacturing', 'Retail'],
+    tags: ['grant', 'small-business'],
+    criteria: ['< 100 employees', 'Revenue under $10M']
+  }
+];
+
+const app = new Hono();
+
+app.get('/v1/health', (c) =>
+  c.json({
+    ok: true,
+    service: 'gov-programs-api'
+  })
+);
+
+app.get('/v1/programs', (c) => c.json(programs));
+
+export default app;


### PR DESCRIPTION
## Summary
- return program responses directly instead of using a redundant serialization helper
- expose a `/v1/programs` endpoint that serves static program metadata

## Testing
- not run (network dependency installation stalled)


------
https://chatgpt.com/codex/tasks/task_e_68d0a260a2748327ba64ecf8e1b99d44