### PR TITLE
refactor: extract RSS tag slug helper

### DIFF
--- a/apps/ingest/src/adapters/adapters.test.ts
+++ b/apps/ingest/src/adapters/adapters.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
-import { rssGenericAdapter } from './rss_generic';
+import { rssGenericAdapter, generateSlug } from './rss_generic';
 import { htmlTableGenericAdapter } from './html_table_generic';
 import { jsonApiGenericAdapter } from './json_api_generic';
 
 const mockUuid = (): (() => `${string}-${string}-${string}-${string}-${string}`) => {
   let counter = 0;
-  return () => `00000000-0000-0000-0000-${(counter++).toString().padStart(12, '0')}` as `${string}-${string}-${string}-${string}-${string}`;
+  return () =>
+    `00000000-0000-4000-8000-${(counter++).toString().padStart(12, '0')}` as `${string}-${string}-${string}-${string}-${string}`;
 };
 
 const createFetch = (body: string, contentType = 'application/xml') =>
@@ -31,6 +32,16 @@ describe('rssGenericAdapter', () => {
     expect(result.programs).toHaveLength(1);
     expect(result.programs[0].title).toBe('Program A');
     expect(result.programs[0].tags[0].label).toBe('Energy');
+  });
+});
+
+describe('generateSlug', () => {
+  test('creates lowercase hyphenated slugs', () => {
+    expect(generateSlug('Energy Efficiency')).toBe('energy-efficiency');
+  });
+
+  test('trims repeated separators from ends', () => {
+    expect(generateSlug('--Already--Normalized--')).toBe('already-normalized');
   });
 });
 

--- a/apps/ingest/src/adapters/rss_generic.ts
+++ b/apps/ingest/src/adapters/rss_generic.ts
@@ -2,6 +2,9 @@ import { load, type Cheerio, type CheerioAPI } from 'cheerio';
 import { parseISO } from 'date-fns';
 import { Program, type Adapter, type AdapterContext, type AdapterResult, type ProgramT } from '@common/types';
 
+export const generateSlug = (label: string): string =>
+  label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
 const parseItem = (item: Cheerio<any>, $: CheerioAPI): ProgramT | null => {
   const title = item.find('title').first().text().trim();
   if (!title) return null;
@@ -29,7 +32,7 @@ const parseItem = (item: Cheerio<any>, $: CheerioAPI): ProgramT | null => {
     startDate,
     tags: categories.map((label) => ({
       id: crypto.randomUUID(),
-      slug: label.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      slug: generateSlug(label),
       label
     }))
   });


### PR DESCRIPTION
## Summary
- extract reusable `generateSlug` helper for RSS adapter tags
- update tests to cover slug generation and use a valid deterministic UUID mock

## Testing
- bun run vitest run apps/ingest/src/adapters/adapters.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0a5386d2c83278c3a3b124c4125ea