### PR TITLE
Extract industry code limit constant

### DIFF
--- a/apps/api/src/query.ts
+++ b/apps/api/src/query.ts
@@ -1,3 +1,5 @@
+const MAX_INDUSTRY_CODES = 100;
+
 type Filters = {
   q?: string;
   country?: string;
@@ -25,11 +27,10 @@ export function buildProgramsQuery(f: Filters) {
 
   if (Array.isArray(f.industry) && f.industry.length > 0) {
     // Limit the number of industry codes to prevent excessively large queries
-    const maxIndustryCodes = 100;
-    if (f.industry.length > maxIndustryCodes) {
-      throw new Error(`Too many industry codes: received ${f.industry.length}, maximum allowed is ${maxIndustryCodes}`);
+    if (f.industry.length > MAX_INDUSTRY_CODES) {
+      throw new Error(`Too many industry codes: received ${f.industry.length}, maximum allowed is ${MAX_INDUSTRY_CODES}`);
     }
-    const industryCodes = f.industry.slice(0, maxIndustryCodes);
+    const industryCodes = f.industry.slice(0, MAX_INDUSTRY_CODES);
     if (industryCodes.length > 0) {
       where.push(`EXISTS (SELECT 1 FROM json_each(programs.industry_codes) WHERE value IN (${industryCodes.map(() => '?').join(',')}))`);
       params.push(...industryCodes);


### PR DESCRIPTION
## Summary
- hoist the maximum industry code limit to a module-level constant
- reuse the shared constant when validating and slicing industry filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0b4a97f948327be8546f5c8eb1859