### PR TITLE
Fix duplicate migrations config

### DIFF
--- a/wrangler.template.toml
+++ b/wrangler.template.toml
@@ -30,8 +30,5 @@ class_name = "__DO_CLASS__"
 tag = "v1"
 new_classes = ["__DO_CLASS__"]
 
-[migrations]
-dir = "migrations"
-
 [triggers]
 crons = ["0 */4 * * *"]


### PR DESCRIPTION
## Summary
- remove the redundant `[migrations]` table from `wrangler.template.toml`
- rely on the existing `[[migrations]]` array to define durable object migrations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0b4cf5a7c8327a55f5d0735674e8b