### PR TITLE
feat(phase3-a): migrations and auth scaffolding

### DIFF
--- a/apps/api/src/mw.auth.ts
+++ b/apps/api/src/mw.auth.ts
@@ -1,0 +1,127 @@
+import type { MiddlewareHandler } from 'hono';
+import type { D1Database } from '@cloudflare/workers-types';
+import type { Env } from './db';
+
+type Role = 'admin' | 'partner' | 'read';
+
+export type AuthInfo = {
+  apiKeyId: number;
+  role: Role;
+  quotaDaily: number | null;
+  quotaMonthly: number | null;
+};
+
+export type AuthVariables = {
+  auth?: AuthInfo;
+};
+
+const encoder = new TextEncoder();
+
+async function hashKey(rawKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(rawKey));
+  const hashArray = Array.from(new Uint8Array(digest));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function getUtcDayStart(now: Date): number {
+  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1000);
+}
+
+function getUtcMonthStart(now: Date): number {
+  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1) / 1000);
+}
+
+async function fetchUsage(env: Env, apiKeyId: number, startTs: number) {
+  const row = await env.DB.prepare(
+    'SELECT COALESCE(SUM(cost), 0) as total FROM usage_events WHERE api_key_id = ? AND ts >= ?'
+  )
+    .bind(apiKeyId, startTs)
+    .first<{ total: number | null }>();
+  return Number(row?.total ?? 0);
+}
+
+export const mwAuth: MiddlewareHandler<{ Bindings: Env; Variables: AuthVariables }> = async (c, next) => {
+  const apiKey = c.req.header('x-api-key');
+  if (!apiKey) {
+    return c.json({ error: 'missing_api_key' }, 401);
+  }
+
+  const keyHash = await hashKey(apiKey);
+  const record = await c.env.DB.prepare(
+    'SELECT id, role, quota_daily, quota_monthly FROM api_keys WHERE key_hash = ? LIMIT 1'
+  )
+    .bind(keyHash)
+    .first<{ id: number; role: Role; quota_daily: number | null; quota_monthly: number | null }>();
+
+  if (!record) {
+    return c.json({ error: 'forbidden' }, 403);
+  }
+
+  const now = new Date();
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  const dayStart = getUtcDayStart(now);
+  const monthStart = getUtcMonthStart(now);
+
+  const [dayUsage, monthUsage] = await Promise.all([
+    fetchUsage(c.env, record.id, dayStart),
+    fetchUsage(c.env, record.id, monthStart)
+  ]);
+
+  if (typeof record.quota_daily === 'number' && dayUsage >= record.quota_daily) {
+    return c.json({ error: 'quota_exceeded', scope: 'daily' }, 429);
+  }
+
+  if (typeof record.quota_monthly === 'number' && monthUsage >= record.quota_monthly) {
+    return c.json({ error: 'quota_exceeded', scope: 'monthly' }, 429);
+  }
+
+  await Promise.all([
+    c.env.DB.prepare(
+      'INSERT INTO usage_events (api_key_id, ts, route, cost) VALUES (?, ?, ?, 1)'
+    )
+      .bind(record.id, nowSeconds, c.req.path)
+      .run(),
+    c.env.DB.prepare('UPDATE api_keys SET last_seen_at = ? WHERE id = ?')
+      .bind(nowSeconds, record.id)
+      .run()
+  ]);
+
+  c.set('auth', {
+    apiKeyId: record.id,
+    role: record.role,
+    quotaDaily: record.quota_daily ?? null,
+    quotaMonthly: record.quota_monthly ?? null
+  });
+
+  await next();
+};
+
+export async function upsertDevApiKey(
+  db: D1Database,
+  params: {
+    rawKey: string;
+    role?: Role;
+    name?: string;
+    quotaDaily?: number | null;
+    quotaMonthly?: number | null;
+  }
+) {
+  const { rawKey, role = 'admin', name = 'dev', quotaDaily = null, quotaMonthly = null } = params;
+  const keyHash = await hashKey(rawKey);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  await db
+    .prepare(
+      `INSERT INTO api_keys (key_hash, role, name, quota_daily, quota_monthly, created_at, updated_at, last_seen_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(key_hash) DO UPDATE SET
+         role = excluded.role,
+         name = excluded.name,
+         quota_daily = excluded.quota_daily,
+         quota_monthly = excluded.quota_monthly,
+         updated_at = excluded.updated_at`
+    )
+    .bind(keyHash, role, name, quotaDaily, quotaMonthly, nowSeconds, nowSeconds, nowSeconds)
+    .run();
+}
+
+export { hashKey };

--- a/apps/api/src/mw.rate.ts
+++ b/apps/api/src/mw.rate.ts
@@ -1,0 +1,38 @@
+import type { MiddlewareHandler } from 'hono';
+
+const RATE_LIMIT = 60;
+const WINDOW_MS = 60_000;
+
+type Bucket = {
+  tokens: number;
+  lastRefill: number;
+};
+
+const buckets = new Map<string, Bucket>();
+
+function refillBucket(bucket: Bucket, now: number) {
+  const elapsed = now - bucket.lastRefill;
+  if (elapsed <= 0) return bucket;
+  const refillTokens = (elapsed / WINDOW_MS) * RATE_LIMIT;
+  const tokens = Math.min(RATE_LIMIT, bucket.tokens + refillTokens);
+  return { tokens, lastRefill: now };
+}
+
+export const mwRate: MiddlewareHandler = async (c, next) => {
+  if (typeof (globalThis as any).Bun === 'undefined') {
+    return next();
+  }
+
+  const now = Date.now();
+  const headerKey = c.req.header('x-api-key') || 'anon';
+  const key = headerKey || 'anon';
+  const bucket = buckets.get(key) ?? { tokens: RATE_LIMIT, lastRefill: now };
+  const refilled = refillBucket(bucket, now);
+  if (refilled.tokens < 1) {
+    buckets.set(key, refilled);
+    return c.json({ error: 'rate_limited' }, 429);
+  }
+
+  buckets.set(key, { tokens: refilled.tokens - 1, lastRefill: refilled.lastRefill });
+  await next();
+};

--- a/apps/api/src/mw.rate.ts
+++ b/apps/api/src/mw.rate.ts
@@ -24,8 +24,7 @@ export const mwRate: MiddlewareHandler = async (c, next) => {
   }
 
   const now = Date.now();
-  const headerKey = c.req.header('x-api-key') || 'anon';
-  const key = headerKey || 'anon';
+  const key = c.req.header('x-api-key') || 'anon';
   const bucket = buckets.get(key) ?? { tokens: RATE_LIMIT, lastRefill: now };
   const refilled = refillBucket(bucket, now);
   if (refilled.tokens < 1) {

--- a/apps/api/src/saved.ts
+++ b/apps/api/src/saved.ts
@@ -1,0 +1,66 @@
+import type { Env } from './db';
+
+export type SavedQuery = {
+  id: number;
+  api_key_id: number;
+  name: string;
+  query_json: string;
+  created_at: number | null;
+  updated_at: number | null;
+};
+
+export type AlertSubscription = {
+  id: number;
+  saved_query_id: number;
+  sink: string;
+  target: string;
+  active: number;
+  created_at: number | null;
+  updated_at: number | null;
+};
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+export async function createSavedQuery(env: Env, apiKeyId: number, data: { name: string; query_json: string }) {
+  const ts = nowSeconds();
+  const result = await env.DB.prepare(
+    'INSERT INTO saved_queries (api_key_id, name, query_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+  )
+    .bind(apiKeyId, data.name, data.query_json, ts, ts)
+    .run();
+  const id = Number(result.meta?.last_row_id ?? 0);
+  return id;
+}
+
+export async function getSavedQuery(env: Env, apiKeyId: number, id: number) {
+  const row = await env.DB.prepare(
+    'SELECT id, api_key_id, name, query_json, created_at, updated_at FROM saved_queries WHERE id = ? AND api_key_id = ? LIMIT 1'
+  )
+    .bind(id, apiKeyId)
+    .first<SavedQuery | null>();
+  return row ?? null;
+}
+
+export async function deleteSavedQuery(env: Env, apiKeyId: number, id: number) {
+  const result = await env.DB.prepare('DELETE FROM saved_queries WHERE id = ? AND api_key_id = ?')
+    .bind(id, apiKeyId)
+    .run();
+  const changes = Number(result.meta?.changes ?? 0);
+  return changes > 0;
+}
+
+export async function createAlertSubscription(
+  env: Env,
+  params: { saved_query_id: number; sink: string; target: string }
+) {
+  const ts = nowSeconds();
+  const result = await env.DB.prepare(
+    'INSERT INTO alert_subscriptions (saved_query_id, sink, target, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
+  )
+    .bind(params.saved_query_id, params.sink, params.target, ts, ts)
+    .run();
+  const id = Number(result.meta?.last_row_id ?? 0);
+  return id;
+}

--- a/migrations/0004_profiles_alerts.sql
+++ b/migrations/0004_profiles_alerts.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS applicant_profiles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key_id INTEGER,
+  name TEXT NOT NULL,
+  country_code TEXT NOT NULL,
+  jurisdiction_code TEXT,
+  naics TEXT,
+  headcount INTEGER,
+  capex_cents INTEGER,
+  start_date TEXT,
+  end_date TEXT,
+  notes TEXT,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS saved_queries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  query_json TEXT NOT NULL,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS alert_subscriptions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  saved_query_id INTEGER NOT NULL,
+  sink TEXT NOT NULL,
+  target TEXT NOT NULL,
+  active INTEGER DEFAULT 1,
+  created_at INTEGER,
+  updated_at INTEGER,
+  FOREIGN KEY (saved_query_id) REFERENCES saved_queries(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS alert_outbox (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  subscription_id INTEGER NOT NULL,
+  payload_json TEXT NOT NULL,
+  queued_at INTEGER NOT NULL,
+  delivered_at INTEGER,
+  attempts INTEGER DEFAULT 0,
+  status TEXT CHECK(status IN ('queued','ok','error')) DEFAULT 'queued'
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_status ON alert_outbox(status, queued_at);

--- a/migrations/0005_auth_usage.sql
+++ b/migrations/0005_auth_usage.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS api_keys (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  key_hash TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL CHECK(role IN ('admin','partner','read')),
+  name TEXT,
+  quota_daily INTEGER,
+  quota_monthly INTEGER,
+  created_at INTEGER,
+  updated_at INTEGER,
+  last_seen_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key_id INTEGER NOT NULL,
+  ts INTEGER NOT NULL,
+  route TEXT NOT NULL,
+  cost INTEGER DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_usage_key_ts ON usage_events(api_key_id, ts DESC);

--- a/tests/auth.quota.test.ts
+++ b/tests/auth.quota.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import type { D1Database } from '@cloudflare/workers-types';
+import app from '../apps/api/src/index';
+import { createTestDB } from './helpers/d1';
+import { upsertDevApiKey } from '../apps/api/src/mw.auth';
+
+const API_KEY = 'quota-test-key';
+
+const schema = `
+CREATE TABLE IF NOT EXISTS api_keys (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  key_hash TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL,
+  name TEXT,
+  quota_daily INTEGER,
+  quota_monthly INTEGER,
+  created_at INTEGER,
+  updated_at INTEGER,
+  last_seen_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key_id INTEGER NOT NULL,
+  ts INTEGER NOT NULL,
+  route TEXT NOT NULL,
+  cost INTEGER DEFAULT 1
+);
+`;
+
+describe('mw.auth quota enforcement', () => {
+  it('rejects requests when daily quota exceeded', async () => {
+    const db = createTestDB();
+    await db.exec(schema);
+    await upsertDevApiKey(db as unknown as D1Database, {
+      rawKey: API_KEY,
+      role: 'partner',
+      quotaDaily: 1,
+      quotaMonthly: 1
+    });
+
+    const env = { DB: db } as any;
+    const request = new Request('http://localhost/v1/usage/me', {
+      headers: { 'x-api-key': API_KEY }
+    });
+    const res1 = await app.fetch(request, env);
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.fetch(
+      new Request('http://localhost/v1/usage/me', { headers: { 'x-api-key': API_KEY } }),
+      env
+    );
+    expect(res2.status).toBe(429);
+    const payload = await res2.json();
+    expect(payload.error).toBe('quota_exceeded');
+    expect(payload.scope).toBe('daily');
+  });
+});

--- a/tests/saved.queries.test.ts
+++ b/tests/saved.queries.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import type { D1Database } from '@cloudflare/workers-types';
+import app from '../apps/api/src/index';
+import { createTestDB } from './helpers/d1';
+import { upsertDevApiKey } from '../apps/api/src/mw.auth';
+
+const API_KEY = 'saved-test-key';
+
+const schema = `
+CREATE TABLE IF NOT EXISTS api_keys (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  key_hash TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL,
+  name TEXT,
+  quota_daily INTEGER,
+  quota_monthly INTEGER,
+  created_at INTEGER,
+  updated_at INTEGER,
+  last_seen_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key_id INTEGER NOT NULL,
+  ts INTEGER NOT NULL,
+  route TEXT NOT NULL,
+  cost INTEGER DEFAULT 1
+);
+CREATE TABLE IF NOT EXISTS saved_queries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  api_key_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  query_json TEXT NOT NULL,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS alert_subscriptions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  saved_query_id INTEGER NOT NULL,
+  sink TEXT NOT NULL,
+  target TEXT NOT NULL,
+  active INTEGER DEFAULT 1,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+`;
+
+describe('saved queries API', () => {
+  it('creates, retrieves, and deletes a saved query', async () => {
+    const db = createTestDB();
+    await db.exec(schema);
+    await upsertDevApiKey(db as unknown as D1Database, {
+      rawKey: API_KEY,
+      role: 'partner',
+      quotaDaily: 10,
+      quotaMonthly: 10
+    });
+
+    const env = { DB: db } as any;
+    const createRes = await app.fetch(
+      new Request('http://localhost/v1/saved-queries', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': API_KEY
+        },
+        body: JSON.stringify({ name: 'My Query', query_json: '{"country":"US"}' })
+      }),
+      env
+    );
+    expect(createRes.status).toBe(200);
+    const { id } = await createRes.json();
+    expect(typeof id).toBe('number');
+
+    const getRes = await app.fetch(
+      new Request(`http://localhost/v1/saved-queries/${id}`, {
+        headers: { 'x-api-key': API_KEY }
+      }),
+      env
+    );
+    expect(getRes.status).toBe(200);
+    const saved = await getRes.json();
+    expect(saved.name).toBe('My Query');
+    expect(saved.query_json).toBe('{"country":"US"}');
+
+    const deleteRes = await app.fetch(
+      new Request(`http://localhost/v1/saved-queries/${id}`, {
+        method: 'DELETE',
+        headers: { 'x-api-key': API_KEY }
+      }),
+      env
+    );
+    expect(deleteRes.status).toBe(200);
+    const delBody = await deleteRes.json();
+    expect(delBody.ok).toBe(true);
+
+    const missingRes = await app.fetch(
+      new Request(`http://localhost/v1/saved-queries/${id}`, {
+        headers: { 'x-api-key': API_KEY }
+      }),
+      env
+    );
+    expect(missingRes.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add phase3 migrations for profiles, saved queries, alerts, and auth usage tables
- implement auth and rate-limit middleware plus saved query, alert, and usage endpoints
- cover middleware and saved query flows with new vitest suites

## Testing
- bun run typecheck
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d172ed15b88327bf2a7008b21e634b