### PR TITLE
Extract shared UTC window helpers

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { listSourcesWithMetrics, buildCoverageResponse } from './coverage';
 import { mwAuth, type AuthVariables } from './mw.auth';
 import { mwRate } from './mw.rate';
 import { createAlertSubscription, createSavedQuery, deleteSavedQuery, getSavedQuery } from './saved';
+import { getUtcDayStart, getUtcMonthStart } from './time';
 
 const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
 
@@ -181,8 +182,8 @@ app.get('/v1/usage/me', async (c) => {
   if (!auth) return c.json({ error: 'unauthorized' }, 401);
   const now = new Date();
   const nowSeconds = Math.floor(now.getTime() / 1000);
-  const dayStart = Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1000);
-  const monthStart = Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1) / 1000);
+  const dayStart = getUtcDayStart(now);
+  const monthStart = getUtcMonthStart(now);
 
   const [dayUsage, monthUsage] = await Promise.all([
     c.env.DB.prepare('SELECT COALESCE(SUM(cost), 0) as total FROM usage_events WHERE api_key_id = ? AND ts >= ?')

--- a/apps/api/src/mw.auth.ts
+++ b/apps/api/src/mw.auth.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareHandler } from 'hono';
 import type { D1Database } from '@cloudflare/workers-types';
 import type { Env } from './db';
+import { getUtcDayStart, getUtcMonthStart } from './time';
 
 type Role = 'admin' | 'partner' | 'read';
 
@@ -21,14 +22,6 @@ async function hashKey(rawKey: string): Promise<string> {
   const digest = await crypto.subtle.digest('SHA-256', encoder.encode(rawKey));
   const hashArray = Array.from(new Uint8Array(digest));
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-function getUtcDayStart(now: Date): number {
-  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1000);
-}
-
-function getUtcMonthStart(now: Date): number {
-  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1) / 1000);
 }
 
 async function fetchUsage(env: Env, apiKeyId: number, startTs: number) {

--- a/apps/api/src/time.ts
+++ b/apps/api/src/time.ts
@@ -1,0 +1,7 @@
+export function getUtcDayStart(date: Date = new Date()): number {
+  return Math.floor(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) / 1000);
+}
+
+export function getUtcMonthStart(date: Date = new Date()): number {
+  return Math.floor(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1) / 1000);
+}


### PR DESCRIPTION
## Summary
- add shared UTC day/month start helpers for API usage windows
- reuse the helpers in auth middleware and usage endpoint to remove duplication

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d18de8e2c0832795814f9cd9dbe445