### PR TITLE
feat(phase4-a): LTR re-ranker + synonyms; rank=ltr on /v1/programs; tests & OpenAPI

### DIFF
--- a/apps/api/src/query.ts
+++ b/apps/api/src/query.ts
@@ -54,7 +54,7 @@ export function buildProgramsQuery(f: Filters) {
   if (f.sort === 'updated_at') orderBy = `ORDER BY updated_at ASC`;
   if (f.sort === '-updated_at') orderBy = `ORDER BY updated_at DESC`;
 
-  const limit = Math.max(1, Math.min(f.limit ?? 25, 100));
+  const limit = Math.max(1, Math.min(f.limit ?? 25, 500));
   const offset = Math.max(0, f.offset ?? 0);
 
   const sql = `

--- a/apps/api/src/synonyms.ts
+++ b/apps/api/src/synonyms.ts
@@ -1,0 +1,32 @@
+import type { Env } from './db';
+
+export async function loadSynonyms(env: Env): Promise<Record<string, string[]>> {
+  if (!env.LOOKUPS_KV) {
+    return {};
+  }
+  try {
+    const stored = await env.LOOKUPS_KV.get('syn:terms', 'json');
+    if (!Array.isArray(stored)) {
+      return {};
+    }
+    const map = new Map<string, Set<string>>();
+    for (const entry of stored) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      const from = String(entry[0]).toLowerCase();
+      const to = String(entry[1]).toLowerCase();
+      if (!from || !to) continue;
+      if (!map.has(from)) {
+        map.set(from, new Set<string>());
+      }
+      map.get(from)?.add(to);
+    }
+    const result: Record<string, string[]> = {};
+    for (const [key, values] of map.entries()) {
+      result[key] = Array.from(values);
+    }
+    return result;
+  } catch (err) {
+    console.warn('synonyms_lookup_failed', err);
+    return {};
+  }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -134,6 +134,26 @@
               "minimum": 1,
               "maximum": 100
             }
+          },
+          {
+            "name": "rank",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ltr"
+              ]
+            },
+            "description": "Optional learning-to-rank strategy"
+          },
+          {
+            "name": "rank_n",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Number of candidates to rerank before paging"
           }
         ],
         "responses": {
@@ -482,6 +502,9 @@
               },
               "pageSize": {
                 "type": "number"
+              },
+              "ranking": {
+                "type": "string"
               }
             },
             "required": [

--- a/packages/ml/src/index.ts
+++ b/packages/ml/src/index.ts
@@ -1,0 +1,2 @@
+export type { LtrWeights, RerankCandidate, RerankResult } from './rerank';
+export { loadLtrWeights, textSim, rerank } from './rerank';

--- a/packages/ml/src/rerank.ts
+++ b/packages/ml/src/rerank.ts
@@ -1,0 +1,177 @@
+export type LtrWeights = {
+  bias: number;
+  w_jur: number;
+  w_ind: number;
+  w_time: number;
+  w_size: number;
+  w_fresh: number;
+  w_text: number;
+};
+
+const DEFAULT_WEIGHTS: LtrWeights = {
+  bias: 0,
+  w_jur: 0.7,
+  w_ind: 0.6,
+  w_time: 0.5,
+  w_size: 0.3,
+  w_fresh: 0.2,
+  w_text: 0.8
+};
+
+function sigmoid(value: number): number {
+  const clamped = Math.max(-20, Math.min(20, value));
+  return 1 / (1 + Math.exp(-clamped));
+}
+
+function normalise(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\p{L}\p{N}]+/gu, ' ')
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function buildNGrams(tokens: string[], n: number): Set<string> {
+  const grams = new Set<string>();
+  if (tokens.length < n || n <= 0) return grams;
+  for (let i = 0; i <= tokens.length - n; i += 1) {
+    grams.add(tokens.slice(i, i + n).join(' '));
+  }
+  return grams;
+}
+
+function expandTokens(tokens: string[], synonyms?: Record<string, string[]>): Set<string> {
+  const expanded = new Set<string>();
+  for (const token of tokens) {
+    const lower = token.toLowerCase();
+    expanded.add(lower);
+    if (!synonyms) continue;
+    const direct = synonyms[lower];
+    if (direct) {
+      for (const alt of direct) {
+        expanded.add(alt.toLowerCase());
+      }
+    }
+  }
+  return expanded;
+}
+
+function overlapScore(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let overlap = 0;
+  for (const value of a) {
+    if (b.has(value)) {
+      overlap += 1;
+    }
+  }
+  return overlap / Math.sqrt(a.size * b.size);
+}
+
+type LookupEnv = { LOOKUPS_KV?: KVNamespace };
+
+export async function loadLtrWeights(env: LookupEnv): Promise<LtrWeights> {
+  if (!env.LOOKUPS_KV) {
+    return DEFAULT_WEIGHTS;
+  }
+  try {
+    const stored = await env.LOOKUPS_KV.get('ltr:weights:v1', 'json');
+    if (stored && typeof stored === 'object') {
+      const data = stored as Partial<LtrWeights>;
+      return {
+        bias: typeof data.bias === 'number' ? data.bias : DEFAULT_WEIGHTS.bias,
+        w_jur: typeof data.w_jur === 'number' ? data.w_jur : DEFAULT_WEIGHTS.w_jur,
+        w_ind: typeof data.w_ind === 'number' ? data.w_ind : DEFAULT_WEIGHTS.w_ind,
+        w_time: typeof data.w_time === 'number' ? data.w_time : DEFAULT_WEIGHTS.w_time,
+        w_size: typeof data.w_size === 'number' ? data.w_size : DEFAULT_WEIGHTS.w_size,
+        w_fresh: typeof data.w_fresh === 'number' ? data.w_fresh : DEFAULT_WEIGHTS.w_fresh,
+        w_text: typeof data.w_text === 'number' ? data.w_text : DEFAULT_WEIGHTS.w_text
+      };
+    }
+  } catch (err) {
+    console.warn('ltr_weights_load_failed', err);
+  }
+  return DEFAULT_WEIGHTS;
+}
+
+export function textSim(
+  q: string,
+  title: string,
+  summary?: string,
+  syn?: Record<string, string[]>
+): number {
+  const qTokens = normalise(q);
+  const titleTokens = normalise(title ?? '');
+  const summaryTokens = summary ? normalise(summary) : [];
+
+  const qExpanded = expandTokens(qTokens, syn);
+  const docTokens = expandTokens([...titleTokens, ...summaryTokens], syn);
+
+  const qBigrams = buildNGrams(Array.from(qExpanded), 2);
+  const docBigrams = buildNGrams(Array.from(docTokens), 2);
+
+  const tokenScore = overlapScore(qExpanded, docTokens);
+  const bigramScore = overlapScore(qBigrams, docBigrams);
+
+  return Number.isFinite(tokenScore + bigramScore)
+    ? Math.min(1, Math.max(0, 0.6 * tokenScore + 0.4 * bigramScore))
+    : 0;
+}
+
+export type RerankCandidate = {
+  row: any;
+  feats: {
+    jur: number;
+    ind: number;
+    time: number;
+    size: number;
+    fresh: number;
+    text: number;
+  };
+};
+
+export type RerankResult = RerankCandidate & {
+  score: number;
+  reasons: {
+    bias: number;
+    jur: number;
+    ind: number;
+    time: number;
+    size: number;
+    fresh: number;
+    text: number;
+  };
+};
+
+export function rerank(cands: RerankCandidate[], weights: LtrWeights): RerankResult[] {
+  const results = cands.map((cand) => {
+    const jur = Number.isFinite(cand.feats.jur) ? cand.feats.jur : 0;
+    const ind = Number.isFinite(cand.feats.ind) ? cand.feats.ind : 0;
+    const time = Number.isFinite(cand.feats.time) ? cand.feats.time : 0;
+    const size = Number.isFinite(cand.feats.size) ? cand.feats.size : 0;
+    const fresh = Number.isFinite(cand.feats.fresh) ? cand.feats.fresh : 0;
+    const text = Number.isFinite(cand.feats.text) ? cand.feats.text : 0;
+
+    const reasons = {
+      bias: weights.bias,
+      jur: weights.w_jur * jur,
+      ind: weights.w_ind * ind,
+      time: weights.w_time * time,
+      size: weights.w_size * size,
+      fresh: weights.w_fresh * fresh,
+      text: weights.w_text * text
+    };
+    const linear =
+      reasons.bias +
+      reasons.jur +
+      reasons.ind +
+      reasons.time +
+      reasons.size +
+      reasons.fresh +
+      reasons.text;
+    const score = sigmoid(linear);
+    return { ...cand, score, reasons };
+  });
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}

--- a/tests/rerank.ltr.test.ts
+++ b/tests/rerank.ltr.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import app from '../apps/api/src/index';
+import { createTestDB } from './helpers/d1';
+import { rerank, textSim, type LtrWeights } from '@ml';
+
+describe('ltr reranker', () => {
+  it('prioritises candidates with closer jurisdiction and industry matches', async () => {
+    const db = createTestDB();
+    await db.exec(`
+      CREATE TABLE programs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        uid TEXT NOT NULL,
+        country_code TEXT NOT NULL,
+        authority_level TEXT NOT NULL,
+        jurisdiction_code TEXT NOT NULL,
+        title TEXT NOT NULL,
+        summary TEXT,
+        industry_codes TEXT,
+        start_date TEXT,
+        end_date TEXT,
+        updated_at INTEGER
+      );
+    `);
+    const now = Date.now();
+    await db.exec(`
+      INSERT INTO programs (uid, country_code, authority_level, jurisdiction_code, title, summary, industry_codes, start_date, end_date, updated_at)
+      VALUES
+        ('p-1', 'US', 'state', 'US-CA', 'Electric Vehicle Infrastructure Grant', 'Supports electric vehicle fleets for car programs.', '["3361"]', NULL, NULL, ${now}),
+        ('p-2', 'US', 'state', 'US-OR', 'Electric Vehicle Pilot Grant', 'Pilot program for electric vehicles.', '["3361"]', NULL, NULL, ${now - 1000}),
+        ('p-3', 'US', 'state', 'US-CA', 'Clean Energy Equipment Grant', 'Supports solar upgrades.', '["2211"]', NULL, NULL, ${now - 2000});
+    `);
+
+    const rows = (await db.prepare('SELECT * FROM programs ORDER BY id').all<any>()).results;
+    const weights: LtrWeights = { bias: 0, w_jur: 0.7, w_ind: 0.6, w_time: 0.5, w_size: 0.3, w_fresh: 0.2, w_text: 0.8 };
+    const synonyms = { car: ['vehicle'] };
+    const ranked = rerank(
+      rows.map((row) => ({
+        row,
+        feats: {
+          jur: row.jurisdiction_code === 'US-CA' ? 1 : 0,
+          ind: row.industry_codes?.includes('3361') ? 1 : 0,
+          time: 0.5,
+          size: 0.5,
+          fresh: 0.8,
+          text: textSim('car grant', row.title, row.summary ?? undefined, synonyms)
+        }
+      })),
+      weights
+    );
+    expect(ranked[0].row.uid).toBe('p-1');
+    expect(ranked[0].reasons.jur).toBeCloseTo(weights.w_jur, 5);
+    expect(ranked[1].row.uid).toBe('p-2');
+  });
+
+  it('reorders /v1/programs with rank=ltr when synonyms expand the query', async () => {
+    const schema = `
+      CREATE TABLE programs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        uid TEXT NOT NULL,
+        country_code TEXT NOT NULL,
+        authority_level TEXT NOT NULL,
+        jurisdiction_code TEXT NOT NULL,
+        title TEXT NOT NULL,
+        summary TEXT,
+        benefit_type TEXT,
+        status TEXT,
+        industry_codes TEXT,
+        start_date TEXT,
+        end_date TEXT,
+        url TEXT,
+        source_id INTEGER,
+        created_at INTEGER,
+        updated_at INTEGER
+      );
+      CREATE TABLE benefits (id INTEGER PRIMARY KEY AUTOINCREMENT, program_id INTEGER, type TEXT, min_amount_cents INTEGER, max_amount_cents INTEGER, currency_code TEXT, notes TEXT);
+      CREATE TABLE criteria (id INTEGER PRIMARY KEY AUTOINCREMENT, program_id INTEGER, kind TEXT, operator TEXT, value TEXT);
+      CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, program_id INTEGER, tag TEXT);
+      CREATE VIRTUAL TABLE programs_fts USING fts5(title, summary, content='programs', content_rowid='id', tokenize='unicode61');
+      CREATE TRIGGER programs_ai AFTER INSERT ON programs BEGIN
+        INSERT INTO programs_fts(rowid, title, summary) VALUES (new.id, new.title, new.summary);
+      END;
+      CREATE TRIGGER programs_ad AFTER DELETE ON programs BEGIN
+        DELETE FROM programs_fts WHERE rowid = old.id;
+      END;
+      CREATE TRIGGER programs_au AFTER UPDATE ON programs BEGIN
+        INSERT INTO programs_fts(programs_fts, rowid, title, summary) VALUES('delete', old.id, old.title, old.summary);
+        INSERT INTO programs_fts(rowid, title, summary) VALUES (new.id, new.title, new.summary);
+      END;
+    `;
+    const db = createTestDB();
+    await db.exec(schema);
+
+    const now = Date.now();
+    await db.exec(`
+      INSERT INTO programs (uid, country_code, authority_level, jurisdiction_code, title, summary, benefit_type, status, industry_codes, created_at, updated_at)
+      VALUES
+        ('veh-1', 'US', 'state', 'US-CA', 'Electric Vehicle Infrastructure Grant', 'Supports electric vehicle fleets for car programs.', 'grant', 'open', '["3361"]', ${now - 2000}, ${now}),
+        ('veh-2', 'US', 'state', 'US-CA', 'Electric Car Infrastructure Grant', 'Supports electric car fleets for public transit.', 'grant', 'open', '["3361"]', ${now - 4000}, ${now - 60000});
+    `);
+
+    const kvData = new Map<string, any>([
+      ['syn:terms', [['car', 'vehicle']]]
+    ]);
+    const env: any = {
+      DB: db,
+      LOOKUPS_KV: {
+        async get(key: string, type?: 'text' | 'json' | 'arrayBuffer'): Promise<any> {
+          if (type === 'json') {
+            return kvData.get(key) ?? null;
+          }
+          return null;
+        }
+      }
+    };
+
+    const baseRes = await app.fetch(
+      new Request('http://localhost/v1/programs?q=car%20grant&country=US&page_size=2'),
+      env
+    );
+    const baseJson = await baseRes.json<any>();
+    expect(baseJson.data[0].title).toContain('Vehicle');
+
+    const ltrRes = await app.fetch(
+      new Request('http://localhost/v1/programs?q=car%20grant&country=US&page_size=2&rank=ltr'),
+      env
+    );
+    const ltrJson = await ltrRes.json<any>();
+    expect(ltrJson.meta.ranking).toBe('ltr');
+    expect(ltrJson.data[0].title).toContain('Car');
+    expect(ltrJson.data[0].id).not.toBe(baseJson.data[0].id);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,13 +30,18 @@
       ],
       "@db/*": [
         "packages/db/src/*"
+      ],
+      "@ml": [
+        "packages/ml/src/index.ts"
+      ],
+      "@ml/*": [
+        "packages/ml/src/*"
       ]
     }
   },
   "include": [
     "apps",
     "packages",
-    "data",
     "scripts",
     "vitest.config.ts"
   ],


### PR DESCRIPTION
## Summary
- add reusable ML reranker with configurable weights and synonym-aware text similarity
- integrate LOOKUPS_KV synonyms + `rank=ltr` flow into `/v1/programs`, reranking top candidates before paging
- document new query params/meta and cover behaviour with new LTR-focused unit/integration tests

## Testing
- bun run typecheck
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d2e74ccff08327b816b802fd1ffc03