### PR TITLE
Adjust ranking defaults and expose scoring constants

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { getUtcDayStart, getUtcMonthStart } from './time';
 
 const MATCH_RESPONSE_LIMIT = 50;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RANK_LIMIT = 200;
 
 function safeNumber(value: any): number | null {
   const num = Number(value);
@@ -87,7 +88,7 @@ function computeTimingFeature(
 
   const overlapDuration = overlapEnd - overlapStart;
   if (!Number.isFinite(overlapDuration) || overlapDuration <= 0) {
-    return 1;
+    return 0;
   }
 
   const profileDuration = profileEnd - profileStart;
@@ -328,7 +329,7 @@ app.get('/v1/programs', async (c) => {
   const isLtr = rankMode === 'ltr';
   const requestedWindow = offset + pageSize;
   const rawRank = Number(qp.get('rank_n'));
-  let rankLimit = Number.isFinite(rawRank) && rawRank > 0 ? Math.floor(rawRank) : 200;
+  let rankLimit = Number.isFinite(rawRank) && rawRank > 0 ? Math.floor(rawRank) : DEFAULT_RANK_LIMIT;
   rankLimit = Math.max(pageSize, Math.min(rankLimit, 500));
   const fetchLimit = isLtr ? Math.max(rankLimit, requestedWindow) : pageSize;
 

--- a/packages/ml/src/rerank.ts
+++ b/packages/ml/src/rerank.ts
@@ -18,8 +18,13 @@ const DEFAULT_WEIGHTS: LtrWeights = {
   w_text: 0.8
 };
 
+const SIGMOID_CLAMP_MIN = -20;
+const SIGMOID_CLAMP_MAX = 20;
+const TOKEN_SCORE_WEIGHT = 0.6;
+const BIGRAM_SCORE_WEIGHT = 0.4;
+
 function sigmoid(value: number): number {
-  const clamped = Math.max(-20, Math.min(20, value));
+  const clamped = Math.max(SIGMOID_CLAMP_MIN, Math.min(SIGMOID_CLAMP_MAX, value));
   return 1 / (1 + Math.exp(-clamped));
 }
 
@@ -114,7 +119,7 @@ export function textSim(
   const bigramScore = overlapScore(qBigrams, docBigrams);
 
   return Number.isFinite(tokenScore + bigramScore)
-    ? Math.min(1, Math.max(0, 0.6 * tokenScore + 0.4 * bigramScore))
+    ? Math.min(1, Math.max(0, TOKEN_SCORE_WEIGHT * tokenScore + BIGRAM_SCORE_WEIGHT * bigramScore))
     : 0;
 }
 


### PR DESCRIPTION
## Summary
- extract the default LTR rank limit to a named constant and ensure timing scores only reward real overlap
- add reusable constants for sigmoid clamping and token/bigram weights in text similarity scoring

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3fdd0521c83279aae2c9d91855dff