### PR TITLE
feat(obs 5C-HF1): metrics DO + request middleware + 5m rollups

### DIFF
--- a/apps/api/src/do.metrics.ts
+++ b/apps/api/src/do.metrics.ts
@@ -1,0 +1,239 @@
+import type { Env } from './db';
+
+export type RequestMetricInput = {
+  route: string;
+  status: number;
+  dur_ms: number;
+  bytes_out: number;
+  ts: number;
+};
+
+export type MetricsReporter = {
+  reportRequest: (metric: RequestMetricInput) => Promise<void>;
+  flush: () => Promise<void>;
+};
+
+type MetricsEnv = Env & {
+  CF_DO_METRICS_BINDING?: string;
+  CF_DO_METRICS_CLASS?: string;
+  [key: string]: unknown;
+};
+
+type AggregationKey = `${number}|${string}|${string}`;
+
+type Aggregation = {
+  bucket: number;
+  route: string;
+  statusClass: string;
+  durations: number[];
+  bytesOut: number;
+};
+
+const REPORTER_SYMBOL = Symbol.for('gov-programs.metrics.reporter');
+const DEFAULT_THRESHOLD = 200;
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+export function statusClass(code: number): '2xx' | '3xx' | '4xx' | '5xx' | 'other' {
+  if (code >= 200 && code < 300) return '2xx';
+  if (code >= 300 && code < 400) return '3xx';
+  if (code >= 400 && code < 500) return '4xx';
+  if (code >= 500 && code < 600) return '5xx';
+  return 'other';
+}
+
+export function toBucket(ts: number): number {
+  const bucket = Math.floor(ts / FIVE_MINUTES_MS) * FIVE_MINUTES_MS;
+  return Number.isFinite(bucket) ? bucket : 0;
+}
+
+export function percentile(sortedDurations: number[], p: number): number {
+  if (sortedDurations.length === 0) return 0;
+  const clamped = Math.min(Math.max(p, 0), 1);
+  const index = Math.ceil(clamped * sortedDurations.length) - 1;
+  const safeIndex = Math.min(sortedDurations.length - 1, Math.max(0, index));
+  return Math.round(sortedDurations[safeIndex]);
+}
+
+class MetricsBuffer {
+  private readonly db: D1Database;
+  private readonly threshold: number;
+  private currentBucket: number | null = null;
+  private totalCount = 0;
+  private readonly buffer = new Map<AggregationKey, Aggregation>();
+
+  constructor(db: D1Database, threshold = DEFAULT_THRESHOLD) {
+    this.db = db;
+    this.threshold = threshold;
+  }
+
+  public isBucketChange(bucket: number): boolean {
+    return this.currentBucket !== null && this.currentBucket !== bucket;
+  }
+
+  public noteBucket(bucket: number) {
+    if (this.currentBucket === null) {
+      this.currentBucket = bucket;
+    }
+  }
+
+  public add(metric: RequestMetricInput, bucket: number, status: string) {
+    const key: AggregationKey = `${bucket}|${metric.route}|${status}`;
+    let agg = this.buffer.get(key);
+    if (!agg) {
+      agg = {
+        bucket,
+        route: metric.route,
+        statusClass: status,
+        durations: [],
+        bytesOut: 0
+      };
+      this.buffer.set(key, agg);
+    }
+    agg.durations.push(metric.dur_ms);
+    agg.bytesOut += Math.max(0, Math.trunc(metric.bytes_out ?? 0));
+    this.totalCount += 1;
+  }
+
+  public async flush(force: boolean) {
+    if (this.totalCount === 0) {
+      this.currentBucket = null;
+      return;
+    }
+    if (!force && this.totalCount < this.threshold) {
+      return;
+    }
+
+    const stmt = this.db.prepare(
+      `INSERT INTO request_metrics_5m (
+        bucket_ts, route, status_class, count, p50_ms, p95_ms, p99_ms, bytes_out
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(bucket_ts, route, status_class) DO UPDATE SET
+        count = excluded.count,
+        p50_ms = excluded.p50_ms,
+        p95_ms = excluded.p95_ms,
+        p99_ms = excluded.p99_ms,
+        bytes_out = excluded.bytes_out`
+    );
+
+    const statements: ReturnType<D1Database['prepare']>[] = [];
+    for (const agg of this.buffer.values()) {
+      const durations = agg.durations.slice().sort((a, b) => a - b);
+      const count = durations.length;
+      const p50 = percentile(durations, 0.5);
+      const p95 = percentile(durations, 0.95);
+      const p99 = percentile(durations, 0.99);
+      const bytesOut = Math.max(0, Math.trunc(agg.bytesOut));
+      statements.push(
+        stmt.bind(agg.bucket, agg.route, agg.statusClass, count, p50, p95, p99, bytesOut)
+      );
+    }
+
+    if (statements.length > 0) {
+      try {
+        await this.db.batch([
+          this.db.prepare('BEGIN'),
+          ...statements,
+          this.db.prepare('COMMIT')
+        ]);
+      } catch (error) {
+        await this.db.batch([this.db.prepare('ROLLBACK')]).catch(() => undefined);
+        throw error;
+      }
+    }
+
+    this.buffer.clear();
+    this.totalCount = 0;
+    this.currentBucket = null;
+  }
+}
+
+function hasDurableObjectNamespace(binding: unknown): binding is DurableObjectNamespace {
+  return Boolean(binding) && typeof binding === 'object' && 'idFromName' in (binding as any);
+}
+
+export class MetricsDO {
+  private readonly buffer: MetricsBuffer;
+
+  constructor(_state: DurableObjectState, env: MetricsEnv) {
+    this.buffer = new MetricsBuffer(env.DB);
+  }
+
+  async fetch(request: Request) {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/request') {
+      const payload = (await request.json().catch(() => null)) as RequestMetricInput | null;
+      if (!payload) {
+        return new Response('invalid body', { status: 400 });
+      }
+      const bucket = toBucket(payload.ts);
+      if (this.buffer.isBucketChange(bucket)) {
+        await this.buffer.flush(true);
+      }
+      this.buffer.noteBucket(bucket);
+      this.buffer.add(payload, bucket, statusClass(payload.status));
+      await this.buffer.flush(false);
+      return new Response('ok', { status: 202 });
+    }
+    if (request.method === 'POST' && url.pathname === '/flush') {
+      await this.buffer.flush(true);
+      return new Response('flushed', { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }
+}
+
+function createDurableReporter(env: MetricsEnv, namespace: DurableObjectNamespace): MetricsReporter {
+  const id = namespace.idFromName('metrics');
+  const stub = namespace.get(id);
+  const base = 'https://metrics';
+  return {
+    async reportRequest(metric: RequestMetricInput) {
+      await stub.fetch(`${base}/request`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(metric)
+      });
+    },
+    async flush() {
+      await stub.fetch(`${base}/flush`, { method: 'POST' });
+    }
+  };
+}
+
+function createFallbackReporter(env: MetricsEnv): MetricsReporter {
+  const buffer = new MetricsBuffer(env.DB);
+  return {
+    async reportRequest(metric: RequestMetricInput) {
+      const bucket = toBucket(metric.ts);
+      if (buffer.isBucketChange(bucket)) {
+        await buffer.flush(true);
+      }
+      buffer.noteBucket(bucket);
+      buffer.add(metric, bucket, statusClass(metric.status));
+      await buffer.flush(false);
+    },
+    async flush() {
+      await buffer.flush(true);
+    }
+  };
+}
+
+export function getMetricsReporter(env: MetricsEnv): MetricsReporter {
+  const cached = (env as any)[REPORTER_SYMBOL] as MetricsReporter | undefined;
+  if (cached) {
+    return cached;
+  }
+  const bindingName = env.CF_DO_METRICS_BINDING;
+  if (bindingName) {
+    const binding = (env as any)[bindingName];
+    if (hasDurableObjectNamespace(binding)) {
+      const reporter = createDurableReporter(env, binding);
+      (env as any)[REPORTER_SYMBOL] = reporter;
+      return reporter;
+    }
+  }
+  const fallback = createFallbackReporter(env);
+  (env as any)[REPORTER_SYMBOL] = fallback;
+  return fallback;
+}
+

--- a/apps/api/src/do.metrics.ts
+++ b/apps/api/src/do.metrics.ts
@@ -131,12 +131,9 @@ class MetricsBuffer {
     if (statements.length > 0) {
       try {
         await this.db.batch([
-          this.db.prepare('BEGIN'),
-          ...statements,
-          this.db.prepare('COMMIT')
+          ...statements
         ]);
       } catch (error) {
-        await this.db.batch([this.db.prepare('ROLLBACK')]).catch(() => undefined);
         throw error;
       }
     }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import { Env } from './db';
 import { buildProgramsQuery } from './query';
 import { listSourcesWithMetrics, buildCoverageResponse, type CoverageResponse } from './coverage';
 import { mwAuth, type AuthVariables } from './mw.auth';
+import { mwMetrics } from './mw.metrics';
 import { mwRate } from './mw.rate';
 import { createAlertSubscription, createSavedQuery, deleteSavedQuery, getSavedQuery } from './saved';
 import { scoreProgramWithReasons, suggestStack, loadWeights, type Profile as MatchProfile, type ProgramRecord } from './match';
@@ -106,6 +107,8 @@ function computeTimingFeature(
 }
 
 const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
+
+app.use('*', mwMetrics);
 
 function parseIndustryCodes(raw: string | null | undefined): string[] {
   if (!raw) return [];

--- a/apps/api/src/mw.metrics.ts
+++ b/apps/api/src/mw.metrics.ts
@@ -1,0 +1,92 @@
+import type { MiddlewareHandler } from 'hono';
+import type { Env } from './db';
+import type { AuthVariables } from './mw.auth';
+import { getMetricsReporter } from './do.metrics';
+
+type MetricsBindings = Env & {
+  METRICS_DISABLE?: string;
+  CF_DO_METRICS_BINDING?: string;
+  CF_DO_METRICS_CLASS?: string;
+};
+
+const MAX_SAMPLE_BYTES = 64 * 1024;
+
+function isMetricsDisabled(env: MetricsBindings): boolean {
+  const flag = env.METRICS_DISABLE;
+  return flag === '1' || flag === 'true';
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function estimateBytesOut(res: Response): Promise<number | null> {
+  try {
+    const headerLength = parseContentLength(res.headers.get('content-length'));
+    if (headerLength !== null) {
+      return headerLength;
+    }
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!contentType.startsWith('text/') && !contentType.startsWith('application/json')) {
+      return null;
+    }
+    const clone = res.clone();
+    if (!clone.body) {
+      return 0;
+    }
+    const reader = clone.body.getReader();
+    let total = 0;
+    while (total <= MAX_SAMPLE_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return total;
+      }
+      total += value?.byteLength ?? 0;
+      if (total > MAX_SAMPLE_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        return null;
+      }
+    }
+    return total;
+  } catch {
+    return null;
+  }
+}
+
+export const mwMetrics: MiddlewareHandler<{ Bindings: MetricsBindings; Variables: AuthVariables }> = async (c, next) => {
+  if (isMetricsDisabled(c.env)) {
+    await next();
+    return;
+  }
+
+  const start = Date.now();
+  const requestId = c.req.header('x-request-id') ?? crypto.randomUUID();
+  try {
+    c.req.raw.headers.set('x-request-id', requestId);
+  } catch {
+    // ignored: Request headers can be immutable in some runtimes
+  }
+
+  await next();
+
+  c.res.headers.set('x-request-id', requestId);
+
+  const durationMs = Math.max(0, Date.now() - start);
+  const bytesOut = (await estimateBytesOut(c.res)) ?? 0;
+  const reporter = getMetricsReporter(c.env as MetricsBindings);
+  const metricTs = Date.now();
+
+  try {
+    await reporter.reportRequest({
+      route: c.req.path,
+      status: c.res.status,
+      dur_ms: durationMs,
+      bytes_out: Math.max(0, Math.trunc(bytesOut)),
+      ts: metricTs
+    });
+  } catch (error) {
+    console.warn('metrics.reportRequest failed', error);
+  }
+};

--- a/apps/api/src/mw.metrics.ts
+++ b/apps/api/src/mw.metrics.ts
@@ -49,7 +49,6 @@ async function estimateBytesOut(res: Response): Promise<number | null> {
         return null;
       }
     }
-    return total;
   } catch {
     return null;
   }

--- a/migrations/0007_ops_metrics.sql
+++ b/migrations/0007_ops_metrics.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS request_metrics_5m (
+  bucket_ts INTEGER NOT NULL,
+  route TEXT NOT NULL,
+  status_class TEXT NOT NULL,
+  count INTEGER NOT NULL,
+  p50_ms INTEGER NOT NULL,
+  p95_ms INTEGER NOT NULL,
+  p99_ms INTEGER NOT NULL,
+  bytes_out INTEGER NOT NULL,
+  PRIMARY KEY(bucket_ts, route, status_class)
+);

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,6 +8,8 @@ KV_LOOKUPS="LOOKUPS"
 KV_API_KEYS="API_KEYS"
 DO_CLASS="RateLimiter"
 DO_BINDING="RATE_LIMITER"
+DO_METRICS_CLASS="MetricsDO"
+DO_METRICS_BINDING="METRICS_AGG"
 TEMPLATE="wrangler.template.toml"
 OUTPUT="wrangler.toml"
 MODE="remote"
@@ -103,6 +105,8 @@ KV[CF_KV_API_KEYS_ID]="${APIKEYS_ID}"
 KV[CF_R2_RAW_BUCKET]="${R2_BUCKET}"
 KV[CF_DO_BINDING]="${DO_BINDING}"
 KV[CF_DO_CLASS]="${DO_CLASS}"
+KV[CF_DO_METRICS_BINDING]="${DO_METRICS_BINDING}"
+KV[CF_DO_METRICS_CLASS]="${DO_METRICS_CLASS}"
 for k in "${!KV[@]}"; do
   if grep -q "^${k}=" "${ENV_FILE}" 2>/dev/null; then
     sed -i.bak "s#^${k}=.*#${k}=${KV[$k]}#g" "${ENV_FILE}"
@@ -165,7 +169,9 @@ s = s
   .replaceAll("__KV_API_KEYS_ID__", env.CF_KV_API_KEYS_ID||"")
   .replaceAll("__R2_BUCKET__", env.CF_R2_RAW_BUCKET||"")
   .replaceAll("__DO_BINDING__", env.CF_DO_BINDING||"")
-  .replaceAll("__DO_CLASS__", env.CF_DO_CLASS||"");
+  .replaceAll("__DO_CLASS__", env.CF_DO_CLASS||"")
+  .replaceAll("__DO_METRICS_BINDING__", env.CF_DO_METRICS_BINDING||"")
+  .replaceAll("__DO_METRICS_CLASS__", env.CF_DO_METRICS_CLASS||"");
 writeFileSync(process.argv[2], s);
 ' "${TEMPLATE}" "${OUTPUT}"
 echo "✅ Generated ${OUTPUT}"

--- a/tests/metrics.requests.test.ts
+++ b/tests/metrics.requests.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createTestDB } from './helpers/d1';
+import { getMetricsReporter } from '../apps/api/src/do.metrics';
+
+beforeAll(() => {
+  process.env.METRICS_DISABLE = '0';
+});
+
+const readMigration = (name: string) =>
+  fs.readFileSync(path.join(process.cwd(), 'migrations', name), 'utf-8');
+
+describe('request metrics reporter', () => {
+  it('aggregates 5-minute request metrics per route and status class', async () => {
+    const db = createTestDB();
+    db.__db__.exec(readMigration('0007_ops_metrics.sql'));
+
+    const env = { DB: db } as any;
+    const reporter = getMetricsReporter(env);
+
+    const baseTs = Date.now();
+    const routes = ['/v1/programs', '/v1/match'];
+    const statuses = [200, 502];
+    let emitted = 0;
+
+    for (const route of routes) {
+      for (const status of statuses) {
+        for (let i = 0; i < 25; i += 1) {
+          const duration = 80 + i * 3 + (status >= 500 ? 40 : 0) + (route === routes[1] ? 10 : 0);
+          const bytes = 512 + i * 11;
+          await reporter.reportRequest({
+            route,
+            status,
+            dur_ms: duration,
+            bytes_out: bytes,
+            ts: baseTs
+          });
+          emitted += 1;
+        }
+      }
+    }
+
+    await reporter.flush();
+
+    const result = await db
+      .prepare('SELECT route, status_class, count, p50_ms, p95_ms, p99_ms, bytes_out FROM request_metrics_5m')
+      .all<{
+        route: string;
+        status_class: string;
+        count: number;
+        p50_ms: number;
+        p95_ms: number;
+        p99_ms: number;
+        bytes_out: number;
+      }>();
+
+    const rows = result.results;
+    expect(rows.length).toBe(routes.length * statuses.length);
+
+    let countSum = 0;
+    for (const row of rows) {
+      countSum += Number(row.count);
+      expect(row.p95_ms).toBeGreaterThanOrEqual(row.p50_ms);
+      expect(row.p99_ms).toBeGreaterThanOrEqual(row.p95_ms);
+      expect(row.bytes_out).toBeGreaterThan(0);
+    }
+
+    expect(countSum).toBe(emitted);
+  });
+});

--- a/wrangler.template.toml
+++ b/wrangler.template.toml
@@ -26,9 +26,17 @@ bucket_name = "__R2_BUCKET__"
 name = "__DO_BINDING__"
 class_name = "__DO_CLASS__"
 
+[[durable_objects.bindings]]
+name = "__DO_METRICS_BINDING__"
+class_name = "__DO_METRICS_CLASS__"
+
 [[migrations]]
 tag = "v1"
 new_classes = ["__DO_CLASS__"]
+
+[[migrations]]
+tag = "v_metrics_v1"
+new_classes = ["__DO_METRICS_CLASS__"]
 
 [triggers]
 crons = ["0 */4 * * *"]


### PR DESCRIPTION
## Summary
- add a request metrics durable object and fallback reporter with 5m rollups in D1
- wire metrics middleware to capture request duration/bytes and send to the reporter
- extend setup tooling and add a migration plus tests covering aggregation behavior

## Testing
- bun run typecheck
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d54f3ee23c8327a60584cafc295306