### PR TITLE
Add deploy workflow with configurable Bun version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,15 +11,13 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      BUN_VERSION: ${{ inputs.bun-version != '' && inputs.bun-version || 'latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          bun-version: ${{ inputs.bun-version }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Deploy with Wrangler

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      bun-version:
+        description: Bun version to install before deployment
+        required: false
+        default: latest
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      BUN_VERSION: ${{ inputs.bun-version != '' && inputs.bun-version || 'latest' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Deploy with Wrangler
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy


### PR DESCRIPTION
## Summary
- allow the deploy workflow to set the Bun version through a workflow input that defaults to the latest release
- add steps to check out the repository, install dependencies, and deploy with Wrangler using the configured Bun version

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d6bad161448327800c3c7c683b525a