### PR TITLE
Add Swagger UI documentation landing page

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
+import openapiDocument from '../../../openapi.json';
 import { Env } from './db';
 import { buildProgramsQuery } from './query';
 import { listSourcesWithMetrics, buildCoverageResponse, type CoverageResponse } from './coverage';
@@ -33,6 +35,78 @@ import {
   buildDecisionResultEmail,
   sendEmail
 } from './onboarding/email';
+
+const DOCS_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Government Programs API</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
+    />
+    <style>
+      body {
+        margin: 0;
+        background: #f8f9fa;
+      }
+      header {
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 24px 32px;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 24px;
+        font-weight: 600;
+      }
+      header p {
+        margin: 8px 0 0 0;
+        max-width: 720px;
+        line-height: 1.4;
+      }
+      #swagger-ui {
+        margin: 24px auto;
+        max-width: 1200px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+        border-radius: 12px;
+      }
+      @media (max-width: 1024px) {
+        #swagger-ui {
+          margin: 16px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Government Programs API</h1>
+      <p>
+        Explore the available endpoints, schemas, and example requests using the
+        interactive documentation below.
+      </p>
+    </header>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js" crossorigin="anonymous"></script>
+    <script>
+      const specUrl = new URL('/openapi.json', window.location.origin).toString();
+      window.addEventListener('load', () => {
+        window.ui = SwaggerUIBundle({
+          url: specUrl,
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          layout: 'BaseLayout',
+          docExpansion: 'none',
+          defaultModelRendering: 'schema',
+        });
+      });
+    </script>
+  </body>
+</html>`;
 
 const MATCH_RESPONSE_LIMIT = 50;
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -206,7 +280,21 @@ function computeTimingFeature(
 
 const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
 
+const serveDocs = (c: Context<{ Bindings: Env; Variables: AuthVariables }>) => {
+  const res = c.html(DOCS_HTML);
+  res.headers.set('Cache-Control', 'public, max-age=300');
+  return res;
+};
+
 app.use('*', mwMetrics);
+
+app.get('/', serveDocs);
+app.get('/docs', serveDocs);
+app.get('/openapi.json', (c) => {
+  const res = c.json(openapiDocument);
+  res.headers.set('Cache-Control', 'public, max-age=300');
+  return res;
+});
 
 function parseIndustryCodes(raw: string | null | undefined): string[] {
   if (!raw) return [];


### PR DESCRIPTION
## Summary
- add a static Swagger UI launch page for the API that serves the OpenAPI spec
- expose the generated OpenAPI document at `/openapi.json` for the interactive docs

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db3639f888832791b9fd04090db6e4