### PR TITLE
Implement phase 2 ingestion catalog and mapper validations

### DIFF
--- a/apps/ingest/src/adapters/mappers.test.ts
+++ b/apps/ingest/src/adapters/mappers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapCkanGC, mapCkanProvON, mapGrantsGov, mapSamAssistance } from './mappers';
+
+describe('mapGrantsGov', () => {
+  it('normalizes opportunity rows and derives status', () => {
+    const result = mapGrantsGov({
+      opportunity: {
+        OpportunityTitle: 'Water Infrastructure Grants',
+        Synopsis: 'Funding for municipal water projects.',
+        PostDate: '2024-01-01',
+        CloseDate: '2100-12-31',
+        OpportunityNumber: 'WATER-123',
+        category: ['infrastructure'],
+        eligibilityCategory: ['municipalities']
+      }
+    });
+
+    expect(result.title).toBe('Water Infrastructure Grants');
+    expect(result.summary).toContain('municipal water');
+    expect(result.url).toBe('https://www.grants.gov/search-results-detail/WATER-123');
+    expect(result.status).toBe('open');
+    expect(result.tags).toEqual(['infrastructure']);
+    expect(result.criteria).toEqual([
+      { kind: 'eligibility', operator: 'matches', value: 'municipalities' }
+    ]);
+  });
+});
+
+describe('mapSamAssistance', () => {
+  it('extracts listing metadata from matched object descriptors', () => {
+    const result = mapSamAssistance({
+      matchedObjectId: '12.345',
+      matchedObjectDescriptor: {
+        assistanceListingTitle: 'Energy Efficiency Support',
+        assistanceListingNumber: '12.345',
+        assistanceListingDescription: 'Support for state-level energy upgrades.',
+        applicantTypes: ['state'],
+        businessCategories: ['energy']
+      }
+    });
+
+    expect(result.title).toBe('Energy Efficiency Support');
+    expect(result.summary).toContain('energy upgrades');
+    expect(result.url).toBe('https://sam.gov/fal/12.345');
+    expect(result.tags).toEqual(['energy']);
+    expect(result.criteria).toEqual([
+      { kind: 'applicant_type', operator: 'eq', value: 'state' }
+    ]);
+  });
+});
+
+describe('mapCkanGC', () => {
+  it('selects preferred resource links and flattens tag names', () => {
+    const result = mapCkanGC({
+      result: {},
+      resources: [
+        { url: 'https://example.com/data.csv', format: 'CSV' },
+        { url: 'https://example.com/info', format: 'HTML' }
+      ],
+      title: 'Innovation Assistance',
+      notes: 'Program details',
+      tags: [{ name: 'innovation' }]
+    });
+
+    expect(result.title).toBe('Innovation Assistance');
+    expect(result.url).toBe('https://example.com/info');
+    expect(result.tags).toEqual(['innovation']);
+  });
+});
+
+describe('mapCkanProvON', () => {
+  it('handles provincial CKAN payloads', () => {
+    const result = mapCkanProvON({
+      title: 'Ontario Technology Grants',
+      description: 'Support for technology firms.',
+      resources: [{ url: 'https://ontario.ca/program', format: 'HTML' }],
+      tags: ['technology']
+    });
+
+    expect(result.title).toBe('Ontario Technology Grants');
+    expect(result.summary).toContain('technology firms');
+    expect(result.url).toBe('https://ontario.ca/program');
+    expect(result.tags).toEqual(['technology']);
+  });
+});

--- a/apps/ingest/src/adapters/mappers.ts
+++ b/apps/ingest/src/adapters/mappers.ts
@@ -50,13 +50,16 @@ export function mapGrantsGov(row: any): MapperResult {
   const url =
     normalized?.url ??
     (opportunityNumber ? `https://www.grants.gov/search-results-detail/${opportunityNumber}` : undefined);
-  const categories = Array.isArray(normalized?.category)
-    ? normalized.category
-    : normalized?.Category
-      ? [normalized.Category]
-      : Array.isArray(normalized?.categories)
-        ? normalized.categories
-        : undefined;
+  let categories;
+  if (Array.isArray(normalized?.category)) {
+    categories = normalized.category;
+  } else if (normalized?.Category) {
+    categories = [normalized.Category];
+  } else if (Array.isArray(normalized?.categories)) {
+    categories = normalized.categories;
+  } else {
+    categories = undefined;
+  }
   const eligibility = Array.isArray(normalized?.eligibilityCategory)
     ? normalized.eligibilityCategory
     : Array.isArray(normalized?.eligibility)

--- a/apps/ingest/src/catalog.ts
+++ b/apps/ingest/src/catalog.ts
@@ -213,6 +213,7 @@ export async function runCatalogOnce(env: IngestEnv, now: Date = new Date()): Pr
           const result = await ingestJsonApiGeneric(env, {
             url: source.entrypoint,
             data: parsed,
+            path: source.path,
             country: source.country,
             authority: source.authority,
             jurisdiction: source.jurisdiction,

--- a/data/sources/phase2.ts
+++ b/data/sources/phase2.ts
@@ -6,6 +6,7 @@ export type SourceDef = {
   kind: 'json' | 'rss' | 'html';
   entrypoint: string;
   parser: 'json_api_generic' | 'rss_generic' | 'html_table_generic';
+  path?: string;
   mapFn?: string;
   rate: { rps: number; burst: number };
   schedule: '4h' | 'daily';
@@ -23,6 +24,7 @@ export const SOURCES: SourceDef[] = [
     entrypoint:
       'https://www.grants.gov/grantsws/rest/opportunities/search?filter=active&sortBy=closeDate',
     parser: 'json_api_generic',
+    path: 'opportunities',
     mapFn: 'mapGrantsGov',
     rate: { rps: 2, burst: 5 },
     schedule: '4h',
@@ -38,6 +40,7 @@ export const SOURCES: SourceDef[] = [
     entrypoint:
       'https://sam.gov/api/prod/sgs/v1/search?index=assistancelisting&q=*&sort=-modifiedDate',
     parser: 'json_api_generic',
+    path: 'searchResult.searchResultItems',
     mapFn: 'mapSamAssistance',
     rate: { rps: 1, burst: 3 },
     schedule: 'daily',
@@ -53,6 +56,7 @@ export const SOURCES: SourceDef[] = [
     entrypoint:
       'https://open.canada.ca/data/en/api/3/action/package_search?q=assistance%20program&rows=100',
     parser: 'json_api_generic',
+    path: 'result.results',
     mapFn: 'mapCkanGC',
     rate: { rps: 1, burst: 2 },
     schedule: 'daily',
@@ -67,6 +71,7 @@ export const SOURCES: SourceDef[] = [
     entrypoint:
       'https://data.ontario.ca/en/api/3/action/package_search?q=grant&rows=100',
     parser: 'json_api_generic',
+    path: 'result.results',
     mapFn: 'mapCkanProvON',
     rate: { rps: 1, burst: 2 },
     schedule: 'daily',


### PR DESCRIPTION
## Summary
- extend the phase 2 source catalog with Grants.gov, SAM, and CKAN feed paths and mapper bindings
- update the ingestion dispatcher to pass nested payload paths when invoking the JSON adapter
- harden mapper implementations and add targeted unit tests for the phase 2 feeds

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68db56f4ae608327b86f2a8cbdae0480