### PR TITLE
Refine CKAN mappers to normalize tags consistently

### DIFF
--- a/apps/ingest/src/adapters/mappers.test.ts
+++ b/apps/ingest/src/adapters/mappers.test.ts
@@ -67,6 +67,16 @@ describe('mapCkanGC', () => {
     expect(result.url).toBe('https://example.com/info');
     expect(result.tags).toEqual(['innovation']);
   });
+
+  it('normalizes mixed CKAN tag representations and defaults the title', () => {
+    const result = mapCkanGC({
+      resources: [],
+      tags: ['clean-tech', { name: 'manufacturing' }, { value: 'ignored' }]
+    });
+
+    expect(result.title).toBe('Government of Canada Program');
+    expect(result.tags).toEqual(['clean-tech', 'manufacturing']);
+  });
 });
 
 describe('mapCkanProvON', () => {

--- a/apps/ingest/src/adapters/mappers.ts
+++ b/apps/ingest/src/adapters/mappers.ts
@@ -113,17 +113,37 @@ export function mapSamAssistance(row: any): MapperResult {
   };
 }
 
+const normalizeCkanTags = (tags: unknown): string[] => {
+  if (Array.isArray(tags)) {
+    return tags
+      .map((tag) => {
+        if (typeof tag === 'string') return tag;
+        if (tag && typeof tag === 'object' && typeof (tag as any).name === 'string') {
+          return (tag as any).name;
+        }
+        return undefined;
+      })
+      .filter((value): value is string => typeof value === 'string' && value.length > 0);
+  }
+  if (typeof tags === 'string') {
+    return tags ? [tags] : [];
+  }
+  return [];
+};
+
 const pickCkanUrl = (resources: any[]): string | undefined => {
   if (!Array.isArray(resources)) return undefined;
-  const preferred = resources.find((r) => typeof r?.url === 'string' && /html|htm/.test(String(r.format ?? '').toLowerCase()));
+  const preferred = resources.find(
+    (r) => typeof r?.url === 'string' && /html|htm/.test(String(r.format ?? '').toLowerCase())
+  );
   if (preferred?.url) return preferred.url;
   const dataset = resources.find((r) => typeof r?.url === 'string');
   return dataset?.url;
 };
 
-export function mapCkanGC(row: any): MapperResult {
+const mapCkanCommon = (row: any, defaultTitle: string): MapperResult => {
   const pkg = row?.package ?? row;
-  const title = pkg?.title ?? 'Government of Canada Program';
+  const title = pkg?.title ?? defaultTitle;
   const summary = pkg?.notes ?? pkg?.description ?? undefined;
   const url = pickCkanUrl(pkg?.resources ?? []);
   return {
@@ -132,23 +152,16 @@ export function mapCkanGC(row: any): MapperResult {
     url,
     status: 'open',
     benefit_type: 'grant',
-    tags: pkg?.tags?.map?.((t: any) => (typeof t === 'string' ? t : t?.name)).filter(Boolean)
+    tags: normalizeCkanTags(pkg?.tags)
   };
+};
+
+export function mapCkanGC(row: any): MapperResult {
+  return mapCkanCommon(row, 'Government of Canada Program');
 }
 
 export function mapCkanProvON(row: any): MapperResult {
-  const pkg = row?.package ?? row;
-  const title = pkg?.title ?? 'Ontario Program';
-  const summary = pkg?.notes ?? pkg?.description ?? undefined;
-  const url = pickCkanUrl(pkg?.resources ?? []);
-  return {
-    title,
-    summary,
-    url,
-    status: 'open',
-    benefit_type: 'grant',
-    tags: pkg?.tags?.map?.((t: any) => (typeof t === 'string' ? t : t?.name)).filter(Boolean)
-  };
+  return mapCkanCommon(row, 'Ontario Program');
 }
 
 export const MAPPERS: Record<string, (row: any) => MapperResult> = {


### PR DESCRIPTION
## Summary
- extract shared helpers for CKAN-based mappers to normalize tags and reuse core mapping logic
- have both Canadian federal and Ontario mappers delegate to the common implementation for consistency
- extend mapper tests to cover mixed tag representations and the default title fallback

## Testing
- bun test
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db6b16c7e88327ad742da372d6ce12