### PR TITLE
Add canvas worker Postmark integration

### DIFF
--- a/CLOUDFLARE_DEPLOYMENT_STEPS.md
+++ b/CLOUDFLARE_DEPLOYMENT_STEPS.md
@@ -8,7 +8,7 @@
 ## 2. Provision core Cloudflare services
 - **D1 database**: `bun run setup:remote` will now detect existing databases and re-use their identifiers—no need to delete and recreate if the name is already provisioned.
 - **DNS**: the deploy script now enforces both `canvas.fungiagricap.com` and `program.fungiagricap.com` A-record placeholders (192.0.2.1, proxied). Ensure the API token has `Zone -> DNS:Edit` for `fungiagricap.com`.
-- **Email routing**: verify that `register@fungiagricap.com` is configured as a sending identity and that MX/SPF/DKIM/DMARC records exist. The deploy script will currently warn if verification fails; add DNS records via the Cloudflare dashboard or automate via API before going live.
+- **Email routing & Postmark**: verify that `register@fungiagricap.com` is configured as a sending identity and that MX/SPF/DKIM/DMARC records exist. In Postmark, provision the transactional "outbound" stream, collect the Server Token, and store it with `bunx wrangler secret put POSTMARK_TOKEN` for both the API and canvas Workers. Add the webhook signing secret with `bunx wrangler secret put POSTMARK_WEBHOOK_SECRET` and point the webhook to `https://canvas.fungiagricap.com/api/postmark/webhook`.
 - **KV / R2**: rerunning `bun run setup:remote` is idempotent—existing namespaces (`LOOKUPS`, `API_KEYS`) and the `gov-programs-api-raw` bucket are discovered via the Cloudflare API instead of re-creation attempts.
 
 ## 3. Deployment workflow

--- a/apps/canvas/src/email.ts
+++ b/apps/canvas/src/email.ts
@@ -1,0 +1,69 @@
+import { isEmailSuppressed } from './suppressions';
+
+export type SendEmailPayload = {
+  to: string;
+  subject: string;
+  text?: string;
+  html?: string;
+  messageStream?: string;
+};
+
+export type EmailEnv = {
+  POSTMARK_TOKEN: string;
+  EMAIL_SENDER: string;
+  DB?: D1Database;
+  POSTMARK_MESSAGE_STREAM?: string;
+};
+
+function ensureRecipient(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('Recipient address is required.');
+  }
+  return trimmed;
+}
+
+function ensureSubject(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('Email subject is required.');
+  }
+  return trimmed;
+}
+
+export async function sendEmail(env: EmailEnv, payload: SendEmailPayload) {
+  const to = ensureRecipient(payload.to);
+  const subject = ensureSubject(payload.subject);
+  const messageStream = payload.messageStream ?? env.POSTMARK_MESSAGE_STREAM ?? 'outbound';
+
+  if (env.DB) {
+    const suppressed = await isEmailSuppressed(env.DB, to);
+    if (suppressed) {
+      throw new Error(`Recipient ${to} is currently suppressed.`);
+    }
+  }
+
+  const res = await fetch('https://api.postmarkapp.com/email', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Postmark-Server-Token': env.POSTMARK_TOKEN
+    },
+    body: JSON.stringify({
+      From: env.EMAIL_SENDER,
+      To: to,
+      Subject: subject,
+      TextBody: payload.text,
+      HtmlBody: payload.html,
+      MessageStream: messageStream
+    })
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Postmark send failed: ${res.status} ${err}`);
+  }
+
+  return res.json();
+}

--- a/apps/canvas/src/env.ts
+++ b/apps/canvas/src/env.ts
@@ -1,0 +1,37 @@
+export type CanvasEnv = {
+  DB: D1Database;
+  POSTMARK_TOKEN?: string;
+  EMAIL_SENDER?: string;
+  POSTMARK_WEBHOOK_SECRET?: string;
+  POSTMARK_MESSAGE_STREAM?: string;
+};
+
+export type ResolvedEmailEnv = {
+  DB?: D1Database;
+  POSTMARK_TOKEN: string;
+  EMAIL_SENDER: string;
+  POSTMARK_MESSAGE_STREAM?: string;
+};
+
+export function resolveEmailEnv(env: CanvasEnv): ResolvedEmailEnv {
+  const token = env.POSTMARK_TOKEN?.trim();
+  if (!token) {
+    throw new Error('POSTMARK_TOKEN is not configured.');
+  }
+  const sender = env.EMAIL_SENDER?.trim();
+  if (!sender) {
+    throw new Error('EMAIL_SENDER is not configured.');
+  }
+  const stream = env.POSTMARK_MESSAGE_STREAM?.trim();
+  return {
+    DB: env.DB,
+    POSTMARK_TOKEN: token,
+    EMAIL_SENDER: sender,
+    POSTMARK_MESSAGE_STREAM: stream?.length ? stream : undefined
+  };
+}
+
+export function getWebhookSecret(env: CanvasEnv): string | null {
+  const secret = env.POSTMARK_WEBHOOK_SECRET?.trim();
+  return secret && secret.length > 0 ? secret : null;
+}

--- a/apps/canvas/src/postmark_webhook.ts
+++ b/apps/canvas/src/postmark_webhook.ts
@@ -1,0 +1,69 @@
+import { getWebhookSecret, type CanvasEnv } from './env';
+import { recordSuppressionEvent, type PostmarkWebhookPayload } from './suppressions';
+
+async function verifySignature(payload: string, signature: string, secret: string) {
+  const normalizedSignature = signature.trim();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+  const signatureBytes = Uint8Array.from(atob(normalizedSignature), (char) => char.charCodeAt(0));
+  const ok = await crypto.subtle.verify('HMAC', key, signatureBytes, new TextEncoder().encode(payload));
+  if (!ok) {
+    throw new Error('invalid signature');
+  }
+}
+
+function parsePayload(body: string): PostmarkWebhookPayload[] {
+  const data = JSON.parse(body) as unknown;
+  if (Array.isArray(data)) {
+    return data.filter((entry): entry is PostmarkWebhookPayload => entry !== null && typeof entry === 'object');
+  }
+  if (data && typeof data === 'object') {
+    return [data as PostmarkWebhookPayload];
+  }
+  throw new Error('invalid payload');
+}
+
+export async function handlePostmarkWebhook(req: Request, env: CanvasEnv): Promise<Response> {
+  if (req.method !== 'POST') {
+    return new Response('method not allowed', { status: 405 });
+  }
+
+  const bodyText = await req.text();
+  const secret = getWebhookSecret(env);
+  if (secret) {
+    const signature = req.headers.get('X-Postmark-Signature');
+    if (!signature) {
+      return new Response('forbidden', { status: 403 });
+    }
+    try {
+      await verifySignature(bodyText, signature, secret);
+    } catch (error) {
+      console.error('Postmark webhook signature validation failed:', error);
+      return new Response('forbidden', { status: 403 });
+    }
+  }
+
+  let events: PostmarkWebhookPayload[];
+  try {
+    events = parsePayload(bodyText);
+  } catch (error) {
+    console.error('Postmark webhook parse error:', error);
+    return new Response('bad request', { status: 400 });
+  }
+
+  try {
+    for (const event of events) {
+      await recordSuppressionEvent(env, event);
+    }
+  } catch (error) {
+    console.error('Postmark webhook persistence failed:', error);
+    return new Response('server error', { status: 500 });
+  }
+
+  return new Response('ok');
+}

--- a/apps/canvas/src/suppressions.ts
+++ b/apps/canvas/src/suppressions.ts
@@ -1,0 +1,183 @@
+import { type CanvasEnv } from './env';
+
+export type PostmarkWebhookPayload = {
+  RecordType: string;
+  Email?: string;
+  Recipient?: string;
+  Target?: string;
+  MessageStream?: string;
+  MessageID?: string;
+  DeliveredAt?: string;
+  BouncedAt?: string;
+  ReceivedAt?: string;
+  ReceivedAtUtc?: string;
+  ReceivedAtUTC?: string;
+  Timestamp?: string;
+  Type?: string;
+  TypeCode?: number;
+  Description?: string;
+  Details?: string;
+  Metadata?: unknown;
+  [key: string]: unknown;
+};
+
+export type NormalizedSuppressionEvent = {
+  email: string;
+  recordType: string;
+  suppressed: boolean;
+  reason?: string | null;
+  description?: string | null;
+  details?: string | null;
+  occurredAt?: string | null;
+  messageStream?: string | null;
+  recordId?: string | null;
+};
+
+export function normalizeEmail(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length ? trimmed : null;
+}
+
+export function deriveSuppressionState(payload: PostmarkWebhookPayload): NormalizedSuppressionEvent | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const recordType = typeof payload.RecordType === 'string' ? payload.RecordType : '';
+  if (!recordType) {
+    return null;
+  }
+  const email =
+    normalizeEmail(payload.Email) ??
+    normalizeEmail(payload.Recipient) ??
+    normalizeEmail(payload.Target);
+  if (!email) {
+    return null;
+  }
+  const reasonCandidate = typeof payload.Type === 'string' ? payload.Type.trim() : '';
+  const typeCode = typeof payload.TypeCode === 'number' ? payload.TypeCode : null;
+  const descriptionCandidate = typeof payload.Description === 'string' ? payload.Description.trim() : '';
+  const detailsCandidate = typeof payload.Details === 'string' ? payload.Details.trim() : '';
+  const suppressed = recordType === 'Bounce' || recordType === 'SpamComplaint';
+  const occurredAt =
+    (typeof payload.BouncedAt === 'string' && payload.BouncedAt) ||
+    (typeof payload.DeliveredAt === 'string' && payload.DeliveredAt) ||
+    (typeof payload.ReceivedAt === 'string' && payload.ReceivedAt) ||
+    (typeof payload.ReceivedAtUTC === 'string' && payload.ReceivedAtUTC) ||
+    (typeof payload.ReceivedAtUtc === 'string' && payload.ReceivedAtUtc) ||
+    (typeof payload.Timestamp === 'string' && payload.Timestamp) ||
+    null;
+  const messageStream = typeof payload.MessageStream === 'string' ? payload.MessageStream.trim() : '';
+  const recordIdCandidate =
+    ((payload as { BounceID?: number }).BounceID ??
+      (payload as { DeliveryID?: number }).DeliveryID ??
+      (payload as { RecordID?: string }).RecordID ??
+      (payload as { RecordId?: string }).RecordId ??
+      payload.MessageID ??
+      (payload as { ID?: string | number }).ID);
+  return {
+    email,
+    recordType,
+    suppressed,
+    reason:
+      reasonCandidate.length
+        ? reasonCandidate
+        : recordType === 'SpamComplaint'
+        ? 'SpamComplaint'
+        : typeCode !== null
+        ? `TypeCode:${typeCode}`
+        : null,
+    description: descriptionCandidate.length ? descriptionCandidate : null,
+    details:
+      detailsCandidate.length
+        ? detailsCandidate
+        : typeCode !== null
+        ? `TypeCode ${typeCode}`
+        : null,
+    occurredAt,
+    messageStream: messageStream.length ? messageStream : null,
+    recordId: recordIdCandidate != null ? String(recordIdCandidate) : null
+  };
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function randomId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+export async function recordSuppressionEvent(env: CanvasEnv, payload: PostmarkWebhookPayload): Promise<void> {
+  const normalized = deriveSuppressionState(payload);
+  if (!normalized) {
+    return;
+  }
+  if (!env.DB) {
+    console.warn('Skipping suppression persistence because DB binding is missing.');
+    return;
+  }
+  const recordedAt = now();
+  const occurredAt = normalized.occurredAt ?? recordedAt;
+  const metadataJson = JSON.stringify(payload);
+
+  await env.DB.prepare(
+    `INSERT INTO email_suppression_events
+      (id, email, event_type, payload, recorded_at, occurred_at, message_stream, record_id)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+  )
+    .bind(
+      randomId('suppevt'),
+      normalized.email,
+      normalized.recordType,
+      metadataJson,
+      recordedAt,
+      occurredAt,
+      normalized.messageStream ?? null,
+      normalized.recordId ?? null
+    )
+    .run();
+
+  await env.DB.prepare(
+    `INSERT INTO email_suppressions
+      (email, suppressed, last_event_type, last_event_at, reason, description, details, message_stream, record_id, metadata, created_at, updated_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11)
+     ON CONFLICT(email) DO UPDATE SET
+       suppressed = excluded.suppressed,
+       last_event_type = excluded.last_event_type,
+       last_event_at = excluded.last_event_at,
+       reason = excluded.reason,
+       description = excluded.description,
+       details = excluded.details,
+       message_stream = excluded.message_stream,
+       record_id = excluded.record_id,
+       metadata = excluded.metadata,
+       updated_at = excluded.updated_at`
+  )
+    .bind(
+      normalized.email,
+      normalized.suppressed ? 1 : 0,
+      normalized.recordType,
+      occurredAt,
+      normalized.reason ?? null,
+      normalized.description ?? null,
+      normalized.details ?? null,
+      normalized.messageStream ?? null,
+      normalized.recordId ?? null,
+      metadataJson,
+      recordedAt
+    )
+    .run();
+}
+
+export async function isEmailSuppressed(db: D1Database, email: string): Promise<boolean> {
+  const normalized = normalizeEmail(email);
+  if (!normalized) {
+    return false;
+  }
+  const record = await db
+    .prepare(`SELECT suppressed FROM email_suppressions WHERE email = ?1 LIMIT 1`)
+    .bind(normalized)
+    .first<{ suppressed: number }>();
+  return record?.suppressed === 1;
+}

--- a/apps/canvas/src/worker.ts
+++ b/apps/canvas/src/worker.ts
@@ -1,0 +1,69 @@
+import { resolveEmailEnv, type CanvasEnv } from './env';
+import { sendEmail } from './email';
+import { handlePostmarkWebhook } from './postmark_webhook';
+
+function jsonResponse(payload: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    ...init
+  });
+}
+
+async function handleAccountApproval(request: Request, env: CanvasEnv): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response('method not allowed', { status: 405 });
+  }
+  const emailEnv = resolveEmailEnv(env);
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: 'invalid JSON body' }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object') {
+    return jsonResponse({ error: 'invalid request body' }, { status: 400 });
+  }
+  const to = typeof (body as { to?: string }).to === 'string' ? (body as { to?: string }).to : null;
+  const subject = typeof (body as { subject?: string }).subject === 'string' ? (body as { subject?: string }).subject : null;
+  const text = typeof (body as { text?: string }).text === 'string' ? (body as { text?: string }).text : null;
+  const html = typeof (body as { html?: string }).html === 'string' ? (body as { html?: string }).html : null;
+  const messageStream = typeof (body as { messageStream?: string }).messageStream === 'string'
+    ? (body as { messageStream?: string }).messageStream
+    : undefined;
+
+  if (!to) {
+    return jsonResponse({ error: 'missing recipient address' }, { status: 400 });
+  }
+
+  const effectiveSubject = subject ?? 'Your account is approved';
+  const effectiveText = text ?? 'Welcome aboard! Your canvas is ready.';
+  const effectiveHtml = html ?? '<p>Welcome aboard! Your canvas is ready.</p>';
+
+  const result = await sendEmail(emailEnv, {
+    to,
+    subject: effectiveSubject,
+    text: effectiveText,
+    html: effectiveHtml,
+    messageStream
+  });
+
+  return jsonResponse({ ok: true, result });
+}
+
+const worker = {
+  async fetch(request: Request, env: CanvasEnv, _ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    switch (url.pathname) {
+      case '/api/account/approve':
+        return handleAccountApproval(request, env);
+      case '/api/postmark/webhook':
+        return handlePostmarkWebhook(request, env);
+      default:
+        return new Response('ready');
+    }
+  }
+};
+
+export default worker;

--- a/apps/canvas/wrangler.template.toml
+++ b/apps/canvas/wrangler.template.toml
@@ -1,0 +1,14 @@
+name = "canvas-app"
+main = "src/worker.ts"
+compatibility_date = "2024-11-12"
+
+[vars]
+EMAIL_SENDER = "register@fungiagricap.com"
+POSTMARK_MESSAGE_STREAM = "outbound"
+POSTMARK_WEBHOOK_SECRET = ""
+
+[[d1_databases]]
+binding = "DB"
+database_name = "canvas-app-db"
+database_id = "__CANVAS_D1_ID__"
+migrations_dir = "../../migrations"

--- a/migrations/0011_postmark_suppressions.sql
+++ b/migrations/0011_postmark_suppressions.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS email_suppressions (
+  email TEXT PRIMARY KEY,
+  suppressed INTEGER NOT NULL DEFAULT 0,
+  last_event_type TEXT NOT NULL,
+  last_event_at TEXT NOT NULL,
+  reason TEXT,
+  description TEXT,
+  details TEXT,
+  message_stream TEXT,
+  record_id TEXT,
+  metadata TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS email_suppression_events (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  recorded_at TEXT NOT NULL,
+  occurred_at TEXT,
+  message_stream TEXT,
+  record_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_suppression_events_email
+  ON email_suppression_events(email);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -184,3 +184,31 @@ export const emailTokens = sqliteTable('email_tokens', {
   accountIdx: index('idx_email_tokens_account').on(table.accountRequestId),
   userIdx: index('idx_email_tokens_user').on(table.userId)
 }));
+
+export const emailSuppressions = sqliteTable('email_suppressions', {
+  email: text('email').primaryKey(),
+  suppressed: integer('suppressed', { mode: 'boolean' }).notNull().default(false),
+  lastEventType: text('last_event_type').notNull(),
+  lastEventAt: text('last_event_at').notNull(),
+  reason: text('reason'),
+  description: text('description'),
+  details: text('details'),
+  messageStream: text('message_stream'),
+  recordId: text('record_id'),
+  metadata: text('metadata'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull()
+});
+
+export const emailSuppressionEvents = sqliteTable('email_suppression_events', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull(),
+  eventType: text('event_type').notNull(),
+  payload: text('payload').notNull(),
+  recordedAt: text('recorded_at').notNull(),
+  occurredAt: text('occurred_at'),
+  messageStream: text('message_stream'),
+  recordId: text('record_id')
+}, (table) => ({
+  emailIdx: index('idx_email_suppression_events_email').on(table.email)
+}));

--- a/tests/postmark_suppressions.test.ts
+++ b/tests/postmark_suppressions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSuppressionState, normalizeEmail, type PostmarkWebhookPayload } from '../apps/canvas/src/suppressions';
+
+describe('normalizeEmail', () => {
+  it('returns lower-cased email', () => {
+    expect(normalizeEmail('User@Example.COM ')).toBe('user@example.com');
+  });
+
+  it('returns null for blank values', () => {
+    expect(normalizeEmail('   ')).toBeNull();
+    expect(normalizeEmail(undefined)).toBeNull();
+  });
+});
+
+describe('deriveSuppressionState', () => {
+  it('normalizes bounce events', () => {
+    const payload: PostmarkWebhookPayload = {
+      RecordType: 'Bounce',
+      Email: 'Person@Example.com',
+      Type: 'HardBounce',
+      Description: 'Mailbox not found',
+      Details: 'Test',
+      BouncedAt: '2024-01-01T00:00:00Z',
+      MessageID: 'abc-123',
+      MessageStream: 'outbound'
+    };
+    const result = deriveSuppressionState(payload);
+    expect(result).not.toBeNull();
+    expect(result?.email).toBe('person@example.com');
+    expect(result?.suppressed).toBe(true);
+    expect(result?.recordType).toBe('Bounce');
+    expect(result?.occurredAt).toBe('2024-01-01T00:00:00Z');
+    expect(result?.messageStream).toBe('outbound');
+    expect(result?.recordId).toBe('abc-123');
+  });
+
+  it('normalizes delivery events as non-suppressed', () => {
+    const payload: PostmarkWebhookPayload = {
+      RecordType: 'Delivery',
+      Recipient: 'deliver@example.com',
+      DeliveredAt: '2024-02-02T00:00:00Z',
+      MessageID: 'xyz',
+      MessageStream: 'broadcast'
+    };
+    const result = deriveSuppressionState(payload);
+    expect(result).not.toBeNull();
+    expect(result?.suppressed).toBe(false);
+    expect(result?.messageStream).toBe('broadcast');
+    expect(result?.recordId).toBe('xyz');
+  });
+
+  it('returns null when no recipient present', () => {
+    const payload: PostmarkWebhookPayload = {
+      RecordType: 'Bounce'
+    };
+    expect(deriveSuppressionState(payload)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated canvas worker that sends approval emails through Postmark and exposes a webhook endpoint for bounce handling
- persist Postmark bounce/complaint metadata to new D1 tables and surface helpers to prevent sending to suppressed recipients
- document the Postmark secrets workflow and add a Wrangler template for the canvas worker configuration

## Testing
- bun run typecheck
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68dbff3f15188327b3361234a482ca3a