### PR TITLE
Fix parameter bindings for email suppression upsert

### DIFF
--- a/apps/canvas/src/suppressions.ts
+++ b/apps/canvas/src/suppressions.ts
@@ -141,7 +141,7 @@ export async function recordSuppressionEvent(env: CanvasEnv, payload: PostmarkWe
   await env.DB.prepare(
     `INSERT INTO email_suppressions
       (email, suppressed, last_event_type, last_event_at, reason, description, details, message_stream, record_id, metadata, created_at, updated_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
      ON CONFLICT(email) DO UPDATE SET
        suppressed = excluded.suppressed,
        last_event_type = excluded.last_event_type,
@@ -165,6 +165,7 @@ export async function recordSuppressionEvent(env: CanvasEnv, payload: PostmarkWe
       normalized.messageStream ?? null,
       normalized.recordId ?? null,
       metadataJson,
+      recordedAt,
       recordedAt
     )
     .run();


### PR DESCRIPTION
## Summary
- correct the email_suppressions insert statement to use unique placeholders for created_at and updated_at
- provide the updated_at value in the bound parameters when persisting suppression events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc06fff7108327acd55726ee0429c1