### PR TITLE
Implement Postmark webhook suppression metrics processing

### DIFF
--- a/apps/canvas/src/postmark_metrics.ts
+++ b/apps/canvas/src/postmark_metrics.ts
@@ -1,0 +1,143 @@
+import type { NormalizedSuppressionEvent } from './suppressions';
+import type { PostmarkWebhookPayload } from './suppressions';
+import type { SuppressionSkipReason } from './suppressions';
+
+export type PostmarkFailureSample = {
+  recordType: string | null;
+  messageStream: string | null;
+  reason: string;
+};
+
+export type PostmarkMetricsSnapshot = {
+  received: number;
+  persisted: number;
+  skipped: number;
+  failures: number;
+  suppressed: number;
+  unsuppressed: number;
+  countsByRecordType: Record<string, number>;
+  countsByMessageStream: Record<string, number>;
+  skippedByReason: Record<SuppressionSkipReason, number>;
+  failureSamples: readonly PostmarkFailureSample[];
+};
+
+const MAX_FAILURE_SAMPLES = 5;
+
+function coerceReason(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'unknown error';
+  }
+}
+
+function coerceRecordType(payload: PostmarkWebhookPayload | NormalizedSuppressionEvent | null): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const candidate = (payload as PostmarkWebhookPayload).RecordType ??
+    (payload as NormalizedSuppressionEvent).recordType;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+}
+
+function coerceMessageStream(payload: PostmarkWebhookPayload | NormalizedSuppressionEvent | null): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const candidate = (payload as PostmarkWebhookPayload).MessageStream ??
+    (payload as NormalizedSuppressionEvent).messageStream ??
+    null;
+  if (typeof candidate !== 'string') {
+    return null;
+  }
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export class PostmarkMetricsCollector {
+  private received = 0;
+  private persisted = 0;
+  private skipped = 0;
+  private failures = 0;
+  private suppressed = 0;
+  private unsuppressed = 0;
+  private readonly countsByRecordType = new Map<string, number>();
+  private readonly countsByMessageStream = new Map<string, number>();
+  private readonly skippedByReason = new Map<SuppressionSkipReason, number>();
+  private readonly failureSamples: PostmarkFailureSample[] = [];
+
+  noteReceived(): void {
+    this.received += 1;
+  }
+
+  notePersisted(event: NormalizedSuppressionEvent): void {
+    this.persisted += 1;
+    if (event.suppressed) {
+      this.suppressed += 1;
+    } else {
+      this.unsuppressed += 1;
+    }
+    const recordType = event.recordType;
+    if (recordType) {
+      this.countsByRecordType.set(recordType, (this.countsByRecordType.get(recordType) ?? 0) + 1);
+    }
+    const messageStream = event.messageStream;
+    if (messageStream) {
+      this.countsByMessageStream.set(
+        messageStream,
+        (this.countsByMessageStream.get(messageStream) ?? 0) + 1
+      );
+    }
+  }
+
+  noteSkipped(reason: SuppressionSkipReason): void {
+    this.skipped += 1;
+    this.skippedByReason.set(reason, (this.skippedByReason.get(reason) ?? 0) + 1);
+  }
+
+  noteFailure(payload: PostmarkWebhookPayload, error: unknown): void {
+    this.failures += 1;
+    if (this.failureSamples.length >= MAX_FAILURE_SAMPLES) {
+      return;
+    }
+    this.failureSamples.push({
+      recordType: coerceRecordType(payload),
+      messageStream: coerceMessageStream(payload),
+      reason: coerceReason(error)
+    });
+  }
+
+  hasFailures(): boolean {
+    return this.failures > 0;
+  }
+
+  snapshot(): PostmarkMetricsSnapshot {
+    const countsByRecordType: Record<string, number> = {};
+    for (const [key, value] of this.countsByRecordType.entries()) {
+      countsByRecordType[key] = value;
+    }
+    const countsByMessageStream: Record<string, number> = {};
+    for (const [key, value] of this.countsByMessageStream.entries()) {
+      countsByMessageStream[key] = value;
+    }
+    const skippedByReason = Object.fromEntries(this.skippedByReason.entries()) as Record<SuppressionSkipReason, number>;
+    return {
+      received: this.received,
+      persisted: this.persisted,
+      skipped: this.skipped,
+      failures: this.failures,
+      suppressed: this.suppressed,
+      unsuppressed: this.unsuppressed,
+      countsByRecordType,
+      countsByMessageStream,
+      skippedByReason,
+      failureSamples: this.failureSamples.slice()
+    };
+  }
+}

--- a/tests/postmark_metrics.test.ts
+++ b/tests/postmark_metrics.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { PostmarkMetricsCollector } from '../apps/canvas/src/postmark_metrics';
+import type { NormalizedSuppressionEvent } from '../apps/canvas/src/suppressions';
+
+const sampleEvent = (overrides: Partial<NormalizedSuppressionEvent> = {}): NormalizedSuppressionEvent => ({
+  email: 'sample@example.com',
+  recordType: overrides.recordType ?? 'Bounce',
+  suppressed: overrides.suppressed ?? true,
+  reason: overrides.reason ?? null,
+  description: overrides.description ?? null,
+  details: overrides.details ?? null,
+  occurredAt: overrides.occurredAt ?? '2024-01-01T00:00:00Z',
+  messageStream: overrides.messageStream ?? 'outbound',
+  recordId: overrides.recordId ?? 'evt'
+});
+
+describe('PostmarkMetricsCollector', () => {
+  it('captures persisted, skipped and failure counts', () => {
+    const collector = new PostmarkMetricsCollector();
+    collector.noteReceived();
+    collector.notePersisted(sampleEvent({ recordType: 'Bounce', suppressed: true, messageStream: 'outbound' }));
+    collector.noteReceived();
+    collector.noteSkipped('invalid-payload');
+    collector.noteReceived();
+    collector.noteFailure({ RecordType: 'SpamComplaint', MessageStream: 'outbound' }, new Error('boom'));
+
+    const snapshot = collector.snapshot();
+    expect(snapshot.received).toBe(3);
+    expect(snapshot.persisted).toBe(1);
+    expect(snapshot.skipped).toBe(1);
+    expect(snapshot.failures).toBe(1);
+    expect(snapshot.suppressed).toBe(1);
+    expect(snapshot.unsuppressed).toBe(0);
+    expect(snapshot.countsByRecordType).toEqual({ Bounce: 1 });
+    expect(snapshot.countsByMessageStream).toEqual({ outbound: 1 });
+    expect(snapshot.skippedByReason).toEqual({ 'invalid-payload': 1 });
+    expect(snapshot.failureSamples).toHaveLength(1);
+    expect(snapshot.failureSamples[0]).toEqual({
+      recordType: 'SpamComplaint',
+      messageStream: 'outbound',
+      reason: 'boom'
+    });
+  });
+
+  it('limits failure samples', () => {
+    const collector = new PostmarkMetricsCollector();
+    for (let i = 0; i < 10; i++) {
+      collector.noteReceived();
+      collector.noteFailure({ RecordType: 'Bounce' }, new Error(`err-${i}`));
+    }
+    expect(collector.snapshot().failureSamples).toHaveLength(5);
+  });
+});

--- a/tests/postmark_suppressions.test.ts
+++ b/tests/postmark_suppressions.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { deriveSuppressionState, normalizeEmail, type PostmarkWebhookPayload } from '../apps/canvas/src/suppressions';
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  deriveSuppressionState,
+  normalizeEmail,
+  recordSuppressionEvent,
+  type PostmarkWebhookPayload
+} from '../apps/canvas/src/suppressions';
+import { createTestDB } from './helpers/d1';
+
+const readMigration = (name: string) => fs.readFileSync(path.join(process.cwd(), 'migrations', name), 'utf-8');
 
 describe('normalizeEmail', () => {
   it('returns lower-cased email', () => {
@@ -54,5 +64,67 @@ describe('deriveSuppressionState', () => {
       RecordType: 'Bounce'
     };
     expect(deriveSuppressionState(payload)).toBeNull();
+  });
+});
+
+describe('recordSuppressionEvent', () => {
+  let env: { DB: ReturnType<typeof createTestDB> };
+
+  beforeEach(() => {
+    const db = createTestDB();
+    db.__db__.exec(readMigration('0011_postmark_suppressions.sql'));
+    env = { DB: db };
+  });
+
+  it('persists suppression events and returns normalized data', async () => {
+    const payload: PostmarkWebhookPayload = {
+      RecordType: 'Bounce',
+      Email: 'persist@example.com',
+      Type: 'HardBounce',
+      MessageStream: 'outbound',
+      BouncedAt: '2024-03-01T00:00:00Z',
+      MessageID: 'evt-1'
+    };
+
+    const result = await recordSuppressionEvent(env as any, payload);
+    expect(result.status).toBe('persisted');
+    if (result.status !== 'persisted') return;
+    expect(result.event.email).toBe('persist@example.com');
+    expect(result.event.recordType).toBe('Bounce');
+    expect(result.event.messageStream).toBe('outbound');
+
+    const suppressionRow = await env.DB
+      .prepare('SELECT suppressed, last_event_type, message_stream FROM email_suppressions WHERE email = ?1')
+      .bind('persist@example.com')
+      .first<{ suppressed: number; last_event_type: string; message_stream: string }>();
+    expect(suppressionRow).not.toBeNull();
+    expect(suppressionRow?.suppressed).toBe(1);
+    expect(suppressionRow?.last_event_type).toBe('Bounce');
+    expect(suppressionRow?.message_stream).toBe('outbound');
+
+    const eventsRow = await env.DB
+      .prepare('SELECT event_type, message_stream, record_id FROM email_suppression_events WHERE email = ?1')
+      .bind('persist@example.com')
+      .first<{ event_type: string; message_stream: string; record_id: string }>();
+    expect(eventsRow).not.toBeNull();
+    expect(eventsRow?.event_type).toBe('Bounce');
+    expect(eventsRow?.record_id).toBe('evt-1');
+  });
+
+  it('returns skipped result when payload is invalid', async () => {
+    const payload: PostmarkWebhookPayload = { RecordType: 'Bounce' };
+    const result = await recordSuppressionEvent(env as any, payload);
+    expect(result).toEqual({ status: 'skipped', reason: 'invalid-payload' });
+  });
+
+  it('returns skipped result when DB binding is missing', async () => {
+    const payload: PostmarkWebhookPayload = {
+      RecordType: 'Bounce',
+      Email: 'skip@example.com'
+    };
+
+    const missingEnv = {};
+    const result = await recordSuppressionEvent(missingEnv as any, payload);
+    expect(result).toEqual({ status: 'skipped', reason: 'missing-db' });
   });
 });


### PR DESCRIPTION
## Summary
- add a metrics collector for Postmark suppression events and integrate it with the webhook persistence loop
- return structured persistence results from suppression recording and cover database + skip scenarios in tests
- extend unit coverage for webhook metrics behaviour and the metrics collector itself

## Testing
- bun test tests/postmark_webhook.test.ts tests/postmark_suppressions.test.ts tests/postmark_metrics.test.ts
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc2ce3ab0483278502ccf597b5b776