### PR TITLE
Add coverage enrichment pipeline and reports

### DIFF
--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -94,9 +94,49 @@ export interface CoverageByBenefitType {
   n: number;
 }
 
+export interface CoverageTagCoverage {
+  withTags: number;
+  withoutTags: number;
+}
+
+export interface CoverageNaicsCoverage {
+  withNaics: number;
+  missingNaics: number;
+}
+
+export interface CoverageValidationIssue {
+  issue: string;
+  count: number;
+}
+
+export interface CoverageReportSummary {
+  day: string;
+  created_at: number;
+  tagCoverage: CoverageTagCoverage;
+  naicsCoverage: CoverageNaicsCoverage;
+  validationIssues: CoverageValidationIssue[];
+}
+
 export interface CoverageResponse {
   byJurisdiction: CoverageByJurisdiction[];
   byBenefit: CoverageByBenefitType[];
+  fresh_sources: Array<{ id: string; last_success_at: number | null }>;
+  completeness: {
+    US: { federal: boolean; states: number };
+    CA: { federal: boolean; provinces: number };
+  };
+  naics_density: number;
+  deadlink_rate: number | null;
+  metrics: {
+    fresh_sources: number;
+    completeness: number;
+    naics_density: number;
+    deadlink_rate: number | null;
+  };
+  tagCoverage: CoverageTagCoverage;
+  naicsCoverage: CoverageNaicsCoverage;
+  validationIssues: CoverageValidationIssue[];
+  reports: CoverageReportSummary[];
 }
 
 export interface HealthResponse {

--- a/apps/ingest/src/backfill.enrichment.ts
+++ b/apps/ingest/src/backfill.enrichment.ts
@@ -1,0 +1,180 @@
+import type { D1Database, D1PreparedStatement } from '@cloudflare/workers-types';
+
+import type { NormalizedProgram } from './normalize';
+import { enrichNaics } from './enrich';
+
+export type EnrichmentBackfillEnv = {
+  DB: D1Database;
+  LOOKUPS_KV?: KVNamespace;
+};
+
+type ProgramRow = {
+  id: number;
+  uid: string;
+  country_code: string;
+  authority_level: string;
+  jurisdiction_code: string;
+  title: string;
+  summary: string | null;
+  benefit_type: string | null;
+  status: string;
+  industry_codes: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  url: string | null;
+  source_id: number | null;
+};
+
+type BenefitRow = {
+  program_id: number;
+  type: string;
+  min_amount_cents: number | null;
+  max_amount_cents: number | null;
+  currency_code: string | null;
+  notes: string | null;
+};
+
+type CriterionRow = {
+  program_id: number;
+  kind: string;
+  operator: string;
+  value: string;
+};
+
+type TagRow = {
+  program_id: number;
+  tag: string;
+};
+
+function parseJsonArray(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map((value) => String(value)) : [];
+  } catch {
+    return [];
+  }
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function buildProgram(row: ProgramRow, benefits: BenefitRow[], criteria: CriterionRow[], tags: string[]): NormalizedProgram {
+  return {
+    uid: row.uid,
+    country_code: row.country_code as NormalizedProgram['country_code'],
+    authority_level: row.authority_level as NormalizedProgram['authority_level'],
+    jurisdiction_code: row.jurisdiction_code,
+    title: row.title,
+    summary: row.summary ?? undefined,
+    benefit_type: (row.benefit_type ?? undefined) as NormalizedProgram['benefit_type'],
+    status: row.status as NormalizedProgram['status'],
+    industry_codes: parseJsonArray(row.industry_codes),
+    start_date: row.start_date ?? undefined,
+    end_date: row.end_date ?? undefined,
+    url: row.url ?? undefined,
+    source_id: row.source_id ?? undefined,
+    benefits: benefits.map((b) => ({
+      type: b.type,
+      min_amount_cents: b.min_amount_cents ?? undefined,
+      max_amount_cents: b.max_amount_cents ?? undefined,
+      currency_code: b.currency_code ?? undefined,
+      notes: b.notes ?? undefined
+    })),
+    criteria: criteria.map((c) => ({
+      kind: c.kind,
+      operator: c.operator as NormalizedProgram['criteria'][number]['operator'],
+      value: c.value
+    })),
+    tags
+  };
+}
+
+export async function runEnrichmentBackfill(env: EnrichmentBackfillEnv): Promise<void> {
+  const programRows = await env.DB.prepare(
+    `SELECT id, uid, country_code, authority_level, jurisdiction_code, title, summary, benefit_type, status, industry_codes, start_date, end_date, url, source_id FROM programs`
+  ).all<ProgramRow>();
+
+  const programs = programRows.results ?? [];
+  if (programs.length === 0) {
+    return;
+  }
+
+  const [benefitRows, criterionRows, tagRows] = await Promise.all([
+    env.DB.prepare(
+      `SELECT program_id, type, min_amount_cents, max_amount_cents, currency_code, notes FROM benefits`
+    ).all<BenefitRow>(),
+    env.DB.prepare(`SELECT program_id, kind, operator, value FROM criteria`).all<CriterionRow>(),
+    env.DB.prepare(`SELECT program_id, tag FROM tags`).all<TagRow>()
+  ]);
+
+  const benefitMap = new Map<number, BenefitRow[]>();
+  for (const row of benefitRows.results ?? []) {
+    const list = benefitMap.get(row.program_id) ?? [];
+    list.push(row);
+    benefitMap.set(row.program_id, list);
+  }
+  const criterionMap = new Map<number, CriterionRow[]>();
+  for (const row of criterionRows.results ?? []) {
+    const list = criterionMap.get(row.program_id) ?? [];
+    list.push(row);
+    criterionMap.set(row.program_id, list);
+  }
+  const tagMap = new Map<number, string[]>();
+  for (const row of tagRows.results ?? []) {
+    const list = tagMap.get(row.program_id) ?? [];
+    list.push(row.tag);
+    tagMap.set(row.program_id, list);
+  }
+
+  const statements: D1PreparedStatement[] = [];
+  const now = Date.now();
+
+  for (const row of programs) {
+    const program = buildProgram(
+      row,
+      benefitMap.get(row.id) ?? [],
+      criterionMap.get(row.id) ?? [],
+      tagMap.get(row.id) ?? []
+    );
+    const enriched = await enrichNaics(program, env);
+
+    const originalCodes = program.industry_codes ?? [];
+    const newCodes = enriched.industry_codes ?? [];
+    const originalTags = program.tags ?? [];
+    const newTags = enriched.tags ?? [];
+
+    const codesChanged = !arraysEqual(originalCodes, newCodes);
+    const tagsChanged = !arraysEqual(originalTags, newTags);
+
+    if (!codesChanged && !tagsChanged) {
+      continue;
+    }
+
+    if (codesChanged) {
+      statements.push(
+        env.DB.prepare(`UPDATE programs SET industry_codes = json(?), updated_at = ? WHERE id = ?`).bind(
+          JSON.stringify(newCodes),
+          now,
+          row.id
+        )
+      );
+    }
+
+    if (tagsChanged) {
+      statements.push(env.DB.prepare(`DELETE FROM tags WHERE program_id = ?`).bind(row.id));
+      for (const tag of newTags) {
+        statements.push(env.DB.prepare(`INSERT INTO tags (program_id, tag) VALUES (?, ?)`).bind(row.id, tag));
+      }
+    }
+  }
+
+  if (statements.length > 0) {
+    await env.DB.batch(statements);
+  }
+}

--- a/apps/ingest/src/enrich.ts
+++ b/apps/ingest/src/enrich.ts
@@ -32,7 +32,7 @@ let mappingCacheStatus: 'ok' | 'error' | null = null;
 
 async function loadSampleLookup(): Promise<NaicsEntry[]> {
   try {
-    const module = await import('../../../data/lookups/naics.sample.json', { assert: { type: 'json' } });
+    const module = await import('../../../data/lookups/naics.sample.json', { with: { type: 'json' } });
     const data = module.default ?? module;
     if (Array.isArray(data)) {
       return data

--- a/apps/ingest/src/enrich.ts
+++ b/apps/ingest/src/enrich.ts
@@ -1,7 +1,10 @@
+import type { D1Database } from '@cloudflare/workers-types';
+
 import type { NormalizedProgram } from './normalize';
 
 type EnrichEnv = {
   LOOKUPS_KV?: KVNamespace;
+  DB?: D1Database;
 };
 
 type NaicsEntry = {
@@ -14,34 +17,187 @@ type CachedLookup = {
   entries: NaicsEntry[];
 };
 
+type IndustryMappingEntry = {
+  tags: string[];
+  confidence: number | null;
+};
+
 const MAX_CODES = 6;
-let cache: CachedLookup | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let lookupCache: CachedLookup | null = null;
+let lookupCacheSource: 'kv' | 'fallback' | null = null;
+let mappingCache: { ts: number; entries: Map<string, IndustryMappingEntry> } | null = null;
+let mappingCacheStatus: 'ok' | 'error' | null = null;
+
+async function loadSampleLookup(): Promise<NaicsEntry[]> {
+  try {
+    const module = await import('../../../data/lookups/naics.sample.json', { assert: { type: 'json' } });
+    const data = module.default ?? module;
+    if (Array.isArray(data)) {
+      return data
+        .map((entry: any) => ({
+          code: String(entry.code ?? entry.naics ?? ''),
+          synonyms: Array.isArray(entry.synonyms)
+            ? entry.synonyms
+                .map((value: any) => String(value ?? '').toLowerCase())
+                .filter((token: string) => token.length > 2)
+            : []
+        }))
+        .filter((entry) => entry.code && entry.synonyms.length > 0);
+    }
+    if (data && typeof data === 'object') {
+      return Object.entries(data as Record<string, string | string[] | { synonyms?: string[] }>)
+        .map(([code, value]) => {
+          if (Array.isArray(value)) {
+            return {
+              code,
+              synonyms: value
+                .map((v) => String(v).toLowerCase())
+                .filter((token) => token.length > 2)
+            };
+          }
+          if (typeof value === 'string') {
+            return {
+              code,
+              synonyms: value
+                .toLowerCase()
+                .split(/\s+/)
+                .filter((token) => token.length > 2)
+            };
+          }
+          if (value && typeof value === 'object' && Array.isArray(value.synonyms)) {
+            return {
+              code,
+              synonyms: value.synonyms
+                .map((v) => String(v).toLowerCase())
+                .filter((token) => token.length > 2)
+            };
+          }
+          return { code, synonyms: [] };
+        })
+        .filter((entry) => entry.code && entry.synonyms.length > 0);
+    }
+  } catch (err) {
+    console.warn('enrich_naics_sample_load_failed', err);
+  }
+  return [];
+}
 
 async function loadLookup(env: EnrichEnv): Promise<NaicsEntry[]> {
-  if (!env.LOOKUPS_KV) return [];
-  const ttlMs = 5 * 60 * 1000;
-  if (cache && Date.now() - cache.ts < ttlMs) {
-    return cache.entries;
+  const hasValidCache = lookupCache && Date.now() - lookupCache.ts < CACHE_TTL_MS;
+  if (hasValidCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
+    return lookupCache.entries;
   }
-  try {
-    const raw = await env.LOOKUPS_KV.get('naics:synonyms:v1', 'json');
-    if (!raw) {
-      cache = { ts: Date.now(), entries: [] };
-      return [];
+
+  let entries: NaicsEntry[] = [];
+  if (env.LOOKUPS_KV) {
+    try {
+      const raw = await env.LOOKUPS_KV.get('naics:synonyms:v1', 'json');
+      if (raw) {
+        entries = Array.isArray(raw)
+          ? raw
+          : Object.entries(raw as Record<string, string[] | { code: string; synonyms: string[] }>)
+              .map(([code, value]) => {
+                if (Array.isArray(value)) return { code, synonyms: value };
+                return { code: value.code ?? code, synonyms: value.synonyms ?? [] };
+              });
+      }
+    } catch (err) {
+      console.warn('enrich_naics_kv_load_failed', err);
     }
-    const entries = Array.isArray(raw)
-      ? raw
-      : Object.entries(raw as Record<string, string[] | { code: string; synonyms: string[] }>)
-          .map(([code, value]) => {
-            if (Array.isArray(value)) return { code, synonyms: value };
-            return { code: value.code ?? code, synonyms: value.synonyms ?? [] };
-          });
-    cache = { ts: Date.now(), entries: entries.map((e) => ({ code: e.code, synonyms: e.synonyms ?? [] })) };
-    return cache.entries;
-  } catch {
-    cache = { ts: Date.now(), entries: [] };
-    return [];
   }
+
+  if (entries.length === 0) {
+    entries = await loadSampleLookup();
+    lookupCacheSource = 'fallback';
+  } else {
+    lookupCacheSource = 'kv';
+  }
+
+  lookupCache = {
+    ts: Date.now(),
+    entries: entries.map((entry) => ({
+      code: entry.code,
+      synonyms: Array.isArray(entry.synonyms)
+        ? entry.synonyms.map((s) => s.toLowerCase()).filter((token) => token.length > 2)
+        : []
+    }))
+  };
+  return lookupCache.entries;
+}
+
+function normalizeTags(raw: unknown): string[] {
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.map((value) => String(value)).filter((value) => value.trim().length > 0);
+      }
+    } catch {
+      // ignore malformed JSON
+    }
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((value) => String(value)).filter((value) => value.trim().length > 0);
+  }
+  return [];
+}
+
+async function loadIndustryMappings(env: EnrichEnv): Promise<Map<string, IndustryMappingEntry>> {
+  if (!env.DB) {
+    return new Map();
+  }
+  const hasValidCache = mappingCache && Date.now() - mappingCache.ts < CACHE_TTL_MS;
+  if (hasValidCache && mappingCacheStatus === 'ok') {
+    return mappingCache.entries;
+  }
+
+  try {
+    const rows = await env.DB.prepare('SELECT naics_code, tags, confidence FROM industry_mappings').all<{
+      naics_code: string;
+      tags: string | null;
+      confidence: number | null;
+    }>();
+
+    const map = new Map<string, IndustryMappingEntry>();
+    for (const row of rows.results ?? []) {
+      if (!row.naics_code) continue;
+      const tags = normalizeTags(row.tags);
+      map.set(String(row.naics_code), {
+        tags,
+        confidence: typeof row.confidence === 'number' ? row.confidence : null
+      });
+    }
+    mappingCache = { ts: Date.now(), entries: map };
+    mappingCacheStatus = 'ok';
+    return map;
+  } catch (err) {
+    console.warn('enrich_industry_mapping_load_failed', err);
+    mappingCache = { ts: Date.now(), entries: new Map() };
+    mappingCacheStatus = 'error';
+    return mappingCache.entries;
+  }
+}
+
+function mergeTags(primary: string[], secondary: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of primary) {
+    const normalized = tag.trim();
+    if (!normalized) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  for (const tag of secondary) {
+    const normalized = tag.trim();
+    if (!normalized) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
 }
 
 const tokenize = (text: string): string[] =>
@@ -77,8 +233,29 @@ export async function enrichNaics(program: NormalizedProgram, env: EnrichEnv): P
       }
     }
   }
+  const codeList = Array.from(codes).slice(0, MAX_CODES);
+
+  let derivedTags: string[] = [];
+  if (codeList.length > 0) {
+    const mappings = await loadIndustryMappings(env);
+    const tagSet = new Set<string>();
+    for (const code of codeList) {
+      const mapping = mappings.get(code);
+      if (!mapping) continue;
+      for (const tag of mapping.tags) {
+        const normalized = String(tag).trim();
+        if (normalized) {
+          tagSet.add(normalized);
+        }
+      }
+    }
+    derivedTags = Array.from(tagSet);
+  }
+
+  const mergedTags = mergeTags(program.tags ?? [], derivedTags);
   return {
     ...program,
-    industry_codes: Array.from(codes).slice(0, MAX_CODES)
+    industry_codes: codeList,
+    tags: mergedTags
   };
 }

--- a/apps/ingest/src/index.ts
+++ b/apps/ingest/src/index.ts
@@ -6,6 +6,7 @@ import { runCatalogOnce } from './catalog';
 import { runOutbox } from './alerts.outbox';
 import { checkDeadlinks } from './deadlinks';
 import { writeDailyCoverage } from './precompute.coverage';
+import { runEnrichmentBackfill } from './backfill.enrichment';
 
 type IngestEnv = {
   DB: D1Database;
@@ -96,6 +97,7 @@ function shouldRunDailyMetrics(event: ScheduledEvent): boolean {
 
 async function runDailyMetrics(env: IngestEnv, event: ScheduledEvent): Promise<void> {
   await checkDeadlinks(env);
+  await runEnrichmentBackfill(env);
   const day = formatDay(getScheduledTime(event));
   await writeDailyCoverage(env, day);
 }

--- a/apps/ingest/src/precompute.coverage.ts
+++ b/apps/ingest/src/precompute.coverage.ts
@@ -121,7 +121,7 @@ function evaluateProgramIssues(
   if (!program.url || program.url.trim().length === 0) {
     issues.push('missing_url');
   }
-  const hasBenefits = benefits.length > 0 || hasBenefitAmounts(benefits);
+  const hasBenefits = benefits.length > 0 && hasBenefitAmounts(benefits);
   if (!hasBenefits) {
     issues.push('missing_benefit_info');
   }

--- a/apps/ingest/src/precompute.coverage.ts
+++ b/apps/ingest/src/precompute.coverage.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from '@cloudflare/workers-types';
+import type { D1Database, D1PreparedStatement } from '@cloudflare/workers-types';
 import { formatDay } from '@common/dates';
 import { type DeadlinkMetricsRecord } from './deadlinks';
 
@@ -62,19 +62,158 @@ type IngestEnv = {
   LOOKUPS_KV?: KVNamespace;
 };
 
+type CoverageProgramRow = {
+  id: number;
+  industry_codes: string | null;
+  summary: string | null;
+  url: string | null;
+  start_date: string | null;
+  end_date: string | null;
+};
+
+type CoverageBenefitRow = {
+  program_id: number;
+  min_amount_cents: number | null;
+  max_amount_cents: number | null;
+};
+
+type CoverageTagRow = {
+  program_id: number;
+  tag: string;
+};
+
+type CoverageIssueAggregate = {
+  issue: string;
+  count: number;
+};
+
+function parseIndustryCodes(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.map((value) => String(value));
+    }
+  } catch {
+    // ignore malformed JSON
+  }
+  return [];
+}
+
+function hasBenefitAmounts(benefits: CoverageBenefitRow[]): boolean {
+  return benefits.some((benefit) => {
+    const min = typeof benefit.min_amount_cents === 'number' ? benefit.min_amount_cents : null;
+    const max = typeof benefit.max_amount_cents === 'number' ? benefit.max_amount_cents : null;
+    return (min !== null && min > 0) || (max !== null && max > 0);
+  });
+}
+
+function evaluateProgramIssues(
+  program: CoverageProgramRow,
+  tags: string[],
+  benefits: CoverageBenefitRow[],
+  now: number
+): string[] {
+  const issues: string[] = [];
+  if (!program.summary || program.summary.trim().length === 0) {
+    issues.push('missing_summary');
+  }
+  if (!program.url || program.url.trim().length === 0) {
+    issues.push('missing_url');
+  }
+  const hasBenefits = benefits.length > 0 || hasBenefitAmounts(benefits);
+  if (!hasBenefits) {
+    issues.push('missing_benefit_info');
+  }
+  if (!program.start_date) {
+    issues.push('missing_start_date');
+  }
+  if (program.end_date) {
+    const parsed = Date.parse(program.end_date);
+    if (!Number.isNaN(parsed) && parsed < now) {
+      issues.push('expired');
+    }
+  }
+  const codes = parseIndustryCodes(program.industry_codes);
+  if (codes.length === 0) {
+    issues.push('missing_naics');
+  }
+  if (tags.length === 0) {
+    issues.push('missing_tags');
+  }
+  return issues;
+}
+
 export async function writeDailyCoverage(env: IngestEnv, dayStr?: string): Promise<void> {
   const now = Date.now();
   const day = dayStr ?? formatDay(now);
   const thirtyDaysAgo = now - THIRTY_DAYS_MS;
 
-  const programsRow = await env.DB.prepare(
-    `SELECT COUNT(*) as total, SUM(CASE WHEN industry_codes IS NOT NULL THEN json_array_length(industry_codes) ELSE 0 END) as total_codes FROM programs`
-  ).first<{ total: number; total_codes: number }>();
+  const programRows = await env.DB.prepare(
+    `SELECT id, industry_codes, summary, url, start_date, end_date FROM programs`
+  ).all<CoverageProgramRow>();
   const freshSourcesRow = await env.DB.prepare(
     `SELECT COUNT(DISTINCT source_id) as fresh FROM programs WHERE source_id IS NOT NULL AND updated_at >= ?`
   )
     .bind(thirtyDaysAgo)
     .first<{ fresh: number }>();
+
+  const [benefitRows, tagRows] = await Promise.all([
+    env.DB.prepare(
+      `SELECT program_id, min_amount_cents, max_amount_cents FROM benefits`
+    ).all<CoverageBenefitRow>(),
+    env.DB.prepare(`SELECT program_id, tag FROM tags`).all<CoverageTagRow>()
+  ]);
+
+  const benefitMap = new Map<number, CoverageBenefitRow[]>();
+  for (const row of benefitRows.results ?? []) {
+    const list = benefitMap.get(row.program_id) ?? [];
+    list.push(row);
+    benefitMap.set(row.program_id, list);
+  }
+  const tagMap = new Map<number, string[]>();
+  for (const row of tagRows.results ?? []) {
+    const list = tagMap.get(row.program_id) ?? [];
+    list.push(row.tag);
+    tagMap.set(row.program_id, list);
+  }
+
+  const programs = programRows.results ?? [];
+  const totalPrograms = programs.length;
+  let totalCodes = 0;
+  let withTags = 0;
+  let withoutTags = 0;
+  let withNaics = 0;
+  let missingNaics = 0;
+  const auditRecords: Array<{ programId: number; issues: string[] }> = [];
+  const issueCounts = new Map<string, number>();
+
+  for (const program of programs) {
+    const codes = parseIndustryCodes(program.industry_codes);
+    totalCodes += codes.length;
+    if (codes.length > 0) {
+      withNaics += 1;
+    } else {
+      missingNaics += 1;
+    }
+
+    const tags = tagMap.get(program.id) ?? [];
+    if (tags.length > 0) {
+      withTags += 1;
+    } else {
+      withoutTags += 1;
+    }
+
+    const benefits = benefitMap.get(program.id) ?? [];
+    const issues = evaluateProgramIssues(program, tags, benefits, now);
+    if (issues.length > 0) {
+      auditRecords.push({ programId: program.id, issues });
+      for (const issue of issues) {
+        const current = issueCounts.get(issue) ?? 0;
+        issueCounts.set(issue, current + 1);
+      }
+    }
+  }
 
   let deadlinkRate: number | null = null;
   if (env.LOOKUPS_KV) {
@@ -90,10 +229,35 @@ export async function writeDailyCoverage(env: IngestEnv, dayStr?: string): Promi
     }
   }
 
-  const totalPrograms = Number(programsRow?.total ?? 0);
-  const totalCodes = Number(programsRow?.total_codes ?? 0);
   const naicsDensity = totalPrograms > 0 ? totalCodes / totalPrograms : 0;
   const freshSources = Number(freshSourcesRow?.fresh ?? 0);
+
+  await env.DB.prepare(`DELETE FROM coverage_audit`).run();
+  if (auditRecords.length > 0) {
+    const inserts: D1PreparedStatement[] = auditRecords.map((record) =>
+      env.DB.prepare(`INSERT INTO coverage_audit (program_id, run_id, issues, created_at) VALUES (?, NULL, ?, ?)`)
+        .bind(record.programId, JSON.stringify(record.issues), now)
+    );
+    await env.DB.batch(inserts);
+  }
+
+  const validationIssues: CoverageIssueAggregate[] = Array.from(issueCounts.entries())
+    .map(([issue, count]) => ({ issue, count }))
+    .sort((a, b) => b.count - a.count);
+
+  await env.DB.prepare(
+    `INSERT INTO coverage_reports (day, run_id, with_tags, without_tags, with_naics, missing_naics, validation_issues, created_at)
+     VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(day) DO UPDATE SET
+       with_tags = excluded.with_tags,
+       without_tags = excluded.without_tags,
+       with_naics = excluded.with_naics,
+       missing_naics = excluded.missing_naics,
+       validation_issues = excluded.validation_issues,
+       created_at = excluded.created_at`
+  )
+    .bind(day, withTags, withoutTags, withNaics, missingNaics, JSON.stringify(validationIssues), now)
+    .run();
 
   await env.DB.prepare(
     `INSERT INTO daily_coverage_stats (day, country_code, jurisdiction_code, n_programs, fresh_sources, naics_density, deadlink_rate, created_at)

--- a/migrations/0012_coverage_enrichment.sql
+++ b/migrations/0012_coverage_enrichment.sql
@@ -1,0 +1,40 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS industry_mappings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  naics_code TEXT NOT NULL,
+  tags TEXT NOT NULL DEFAULT '[]',
+  confidence REAL,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_industry_mappings_code ON industry_mappings(naics_code);
+
+CREATE TABLE IF NOT EXISTS coverage_audit (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  program_id INTEGER NOT NULL,
+  run_id INTEGER,
+  issues TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (program_id) REFERENCES programs(id) ON DELETE CASCADE,
+  FOREIGN KEY (run_id) REFERENCES ingestion_runs(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_coverage_audit_program ON coverage_audit(program_id);
+CREATE INDEX IF NOT EXISTS idx_coverage_audit_run ON coverage_audit(run_id);
+
+CREATE TABLE IF NOT EXISTS coverage_reports (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  day TEXT NOT NULL,
+  run_id INTEGER,
+  with_tags INTEGER NOT NULL DEFAULT 0,
+  without_tags INTEGER NOT NULL DEFAULT 0,
+  with_naics INTEGER NOT NULL DEFAULT 0,
+  missing_naics INTEGER NOT NULL DEFAULT 0,
+  validation_issues TEXT NOT NULL DEFAULT '[]',
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (run_id) REFERENCES ingestion_runs(id) ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_coverage_reports_day ON coverage_reports(day);

--- a/openapi.json
+++ b/openapi.json
@@ -648,7 +648,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "number"
           },
           "source_id": {
             "type": "number"
@@ -664,6 +664,9 @@
             ]
           },
           "authority": {
+            "type": "string"
+          },
+          "authority_level": {
             "type": "string"
           },
           "jurisdiction_code": {
@@ -816,11 +819,150 @@
             "items": {
               "$ref": "#/components/schemas/CoverageByBenefitType"
             }
+          },
+          "fresh_sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "last_success_at": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "last_success_at"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "completeness": {
+            "type": "object",
+            "properties": {
+              "US": {
+                "type": "object",
+                "properties": {
+                  "federal": {
+                    "type": "boolean"
+                  },
+                  "states": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "federal",
+                  "states"
+                ],
+                "additionalProperties": false
+              },
+              "CA": {
+                "type": "object",
+                "properties": {
+                  "federal": {
+                    "type": "boolean"
+                  },
+                  "provinces": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "federal",
+                  "provinces"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "US",
+              "CA"
+            ],
+            "additionalProperties": false
+          },
+          "naics_density": {
+            "type": "number"
+          },
+          "deadlink_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metrics": {
+            "type": "object",
+            "properties": {
+              "fresh_sources": {
+                "type": "number"
+              },
+              "completeness": {
+                "type": "number"
+              },
+              "naics_density": {
+                "type": "number"
+              },
+              "deadlink_rate": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "fresh_sources",
+              "completeness",
+              "naics_density",
+              "deadlink_rate"
+            ],
+            "additionalProperties": false
+          },
+          "tagCoverage": {
+            "$ref": "#/components/schemas/CoverageTagCoverage"
+          },
+          "naicsCoverage": {
+            "$ref": "#/components/schemas/CoverageNaicsCoverage"
+          },
+          "validationIssues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoverageValidationIssue"
+            }
+          },
+          "reports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoverageReportSummary"
+            }
           }
         },
         "required": [
           "byJurisdiction",
-          "byBenefit"
+          "byBenefit",
+          "fresh_sources",
+          "completeness",
+          "naics_density",
+          "deadlink_rate",
+          "metrics",
+          "tagCoverage",
+          "naicsCoverage",
+          "validationIssues",
+          "reports"
         ],
         "additionalProperties": false
       },
@@ -864,6 +1006,85 @@
         "required": [
           "benefit_type",
           "n"
+        ],
+        "additionalProperties": false
+      },
+      "CoverageTagCoverage": {
+        "type": "object",
+        "properties": {
+          "withTags": {
+            "type": "number"
+          },
+          "withoutTags": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "withTags",
+          "withoutTags"
+        ],
+        "additionalProperties": false
+      },
+      "CoverageNaicsCoverage": {
+        "type": "object",
+        "properties": {
+          "withNaics": {
+            "type": "number"
+          },
+          "missingNaics": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "withNaics",
+          "missingNaics"
+        ],
+        "additionalProperties": false
+      },
+      "CoverageValidationIssue": {
+        "type": "object",
+        "properties": {
+          "issue": {
+            "type": "string"
+          },
+          "count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "issue",
+          "count"
+        ],
+        "additionalProperties": false
+      },
+      "CoverageReportSummary": {
+        "type": "object",
+        "properties": {
+          "day": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "tagCoverage": {
+            "$ref": "#/components/schemas/CoverageTagCoverage"
+          },
+          "naicsCoverage": {
+            "$ref": "#/components/schemas/CoverageNaicsCoverage"
+          },
+          "validationIssues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoverageValidationIssue"
+            }
+          }
+        },
+        "required": [
+          "day",
+          "created_at",
+          "tagCoverage",
+          "naicsCoverage",
+          "validationIssues"
         ],
         "additionalProperties": false
       },

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, integer, text, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, integer, text, index, uniqueIndex, real } from 'drizzle-orm/sqlite-core';
 
 export const programs = sqliteTable('programs', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -89,6 +89,21 @@ export const countryPlaybooks = sqliteTable('country_playbooks', {
   updatedAt: integer('updated_at').notNull()                                // epoch ms
 });
 
+export const industryMappings = sqliteTable(
+  'industry_mappings',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    naicsCode: text('naics_code').notNull(),
+    tags: text('tags').notNull().default('[]'),
+    confidence: real('confidence'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull()
+  },
+  (table) => ({
+    codeIdx: uniqueIndex('idx_industry_mappings_code').on(table.naicsCode)
+  })
+);
+
 export const users = sqliteTable('users', {
   id: text('id').primaryKey(),
   email: text('email').notNull().unique(),
@@ -158,6 +173,39 @@ export const canvases = sqliteTable('canvases', {
 }, (table) => ({
   ownerIdx: index('idx_canvases_owner').on(table.ownerId)
 }));
+
+export const coverageAudit = sqliteTable(
+  'coverage_audit',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    programId: integer('program_id').notNull(),
+    runId: integer('run_id'),
+    issues: text('issues').notNull(),
+    createdAt: integer('created_at').notNull()
+  },
+  (table) => ({
+    programIdx: index('idx_coverage_audit_program').on(table.programId),
+    runIdx: index('idx_coverage_audit_run').on(table.runId)
+  })
+);
+
+export const coverageReports = sqliteTable(
+  'coverage_reports',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    day: text('day').notNull(),
+    runId: integer('run_id'),
+    withTags: integer('with_tags').notNull().default(0),
+    withoutTags: integer('without_tags').notNull().default(0),
+    withNaics: integer('with_naics').notNull().default(0),
+    missingNaics: integer('missing_naics').notNull().default(0),
+    validationIssues: text('validation_issues').notNull().default('[]'),
+    createdAt: integer('created_at').notNull()
+  },
+  (table) => ({
+    dayIdx: uniqueIndex('idx_coverage_reports_day').on(table.day)
+  })
+);
 
 export const canvasVersions = sqliteTable('canvas_versions', {
   id: text('id').primaryKey(),

--- a/tests/enrich.naics.test.ts
+++ b/tests/enrich.naics.test.ts
@@ -8,6 +8,16 @@ const mockKV = (data: any) => ({
   }
 }) as KVNamespace;
 
+const mockDb = (rows: any[]) => ({
+  prepare() {
+    return {
+      async all() {
+        return { results: rows };
+      }
+    };
+  }
+});
+
 describe('enrichNaics', () => {
   it('assigns NAICS codes from lookup synonyms', async () => {
     const env = { LOOKUPS_KV: mockKV([{ code: '111110', synonyms: ['agriculture'] }]) };
@@ -44,5 +54,37 @@ describe('enrichNaics', () => {
     } as any;
     const enriched = await enrichNaics(program, {});
     expect(enriched.industry_codes).toEqual(['999999']);
+  });
+
+  it('merges adapter tags with derived tags from industry mappings', async () => {
+    const env = {
+      LOOKUPS_KV: mockKV([{ code: '111110', synonyms: ['agriculture'] }]),
+      DB: mockDb([
+        {
+          naics_code: '111110',
+          tags: JSON.stringify(['agtech', 'farming'])
+        }
+      ])
+    };
+    const program = {
+      uid: 'p-test',
+      title: 'Agriculture innovation grant',
+      summary: 'Support for agriculture and farming co-ops',
+      country_code: 'US',
+      authority_level: 'state',
+      jurisdiction_code: 'US-WA',
+      status: 'open',
+      industry_codes: [],
+      benefits: [],
+      criteria: [],
+      tags: ['existing']
+    } as any;
+
+    const enriched = await enrichNaics(program, env as any);
+    expect(enriched.industry_codes).toContain('111110');
+    expect(enriched.tags).toContain('existing');
+    expect(enriched.tags).toContain('agtech');
+    expect(enriched.tags).toContain('farming');
+    expect(new Set(enriched.tags).size).toBe(enriched.tags.length);
   });
 });


### PR DESCRIPTION
## Summary
- add industry_mappings, coverage_audit, and coverage_reports tables with Drizzle models
- extend ingestion enrichment to merge NAICS-derived tags, add nightly backfill, and persist coverage validation results
- enhance /v1/stats/coverage output and OpenAPI schema with tag/NAICS coverage, validation issues, and report history

## Testing
- bun run typecheck
- bun run test

------
https://chatgpt.com/codex/tasks/task_e_68dc574e86fc8327ba9edf1a43d7d8fc