### PR TITLE
Add KV mock expectations to coverage integration test

### DIFF
--- a/tests/coverage.integration.test.ts
+++ b/tests/coverage.integration.test.ts
@@ -263,6 +263,11 @@ describe('coverage integration flow', () => {
 
     await writeDailyCoverage({ DB: db, LOOKUPS_KV: lookups }, COVERAGE_DAY);
 
+    expect(lookupsGet).toHaveBeenCalledWith(`metrics:deadlinks:${COVERAGE_DAY}`, 'json');
+    expect(lookups.put).not.toHaveBeenCalled();
+    expect(lookups.delete).not.toHaveBeenCalled();
+    expect(lookups.list).not.toHaveBeenCalled();
+
     const reportRows = await db
       .prepare(
         `SELECT day, with_tags, without_tags, with_naics, missing_naics, validation_issues, created_at


### PR DESCRIPTION
## Summary
- add assertions ensuring the KVNamespace mock is used as expected in the coverage integration test
- verify the deadlink metrics lookup is called and other KV operations remain unused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc6854b4d08327990ad3b7830518cc