### PR TITLE
Add ingestion run observability and diff tooling

### DIFF
--- a/apps/ingest/src/adapters/html_table_generic.ts
+++ b/apps/ingest/src/adapters/html_table_generic.ts
@@ -25,6 +25,7 @@ export async function ingestHtmlTableGeneric(env: IngestEnv, opts: {
   jurisdiction: string;
   limit?: number;
   sourceId?: number;
+  runId?: number;
 }): Promise<HtmlResult> {
   const html = opts.html ?? await (await fetch(opts.url)).text();
   const $ = cheerio.load(html);
@@ -62,6 +63,6 @@ export async function ingestHtmlTableGeneric(env: IngestEnv, opts: {
       }
     };
   });
-  const outcomes = await upsertPrograms(env, payload as any);
+  const outcomes = await upsertPrograms(env, payload as any, { runId: opts.runId });
   return { attempted: payload.length, outcomes };
 }

--- a/apps/ingest/src/adapters/json_api_generic.ts
+++ b/apps/ingest/src/adapters/json_api_generic.ts
@@ -44,6 +44,7 @@ export async function ingestJsonApiGeneric(env: IngestEnv, opts: {
   jurisdiction: string;
   limit?: number;
   sourceId?: number;
+  runId?: number;
 }): Promise<JsonApiResult> {
   const mapper = resolveMapper(opts.map, opts.mapFn);
   const json = opts.data ?? await (await fetch(opts.url)).json();
@@ -74,6 +75,6 @@ export async function ingestJsonApiGeneric(env: IngestEnv, opts: {
       }
     };
   });
-  const outcomes = await upsertPrograms(env, payload as any);
+  const outcomes = await upsertPrograms(env, payload as any, { runId: opts.runId });
   return { attempted: payload.length, outcomes };
 }

--- a/apps/ingest/src/adapters/rss_generic.ts
+++ b/apps/ingest/src/adapters/rss_generic.ts
@@ -27,6 +27,7 @@ export async function ingestRssGeneric(env: IngestEnv, opts: {
   }>;
   limit?: number;
   sourceId?: number;
+  runId?: number;
 }): Promise<RssResult> {
   const xml = opts.feed ?? await (await fetch(opts.url)).text();
   const $ = cheerio.load(xml, { xmlMode: true });
@@ -59,6 +60,6 @@ export async function ingestRssGeneric(env: IngestEnv, opts: {
       }
     };
   });
-  const outcomes = await upsertPrograms(env, payload as any);
+  const outcomes = await upsertPrograms(env, payload as any, { runId: opts.runId });
   return { attempted: payload.length, outcomes };
 }

--- a/apps/ingest/src/diff/json.test.ts
+++ b/apps/ingest/src/diff/json.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffJson, summarizeDiff } from './json';
+
+describe('diffJson', () => {
+  it('flags critical status change', () => {
+    const before = { status: 'open', start_date: '2024-01-01' };
+    const after = { status: 'closed', start_date: '2024-01-01' };
+    const changes = diffJson(before, after, {
+      critical: ['status'],
+      ignore: []
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ path: 'status', critical: true, kind: 'changed' });
+  });
+
+  it('ignores summary fields when configured', () => {
+    const before = { summary: 'old', status: 'open' };
+    const after = { summary: 'new', status: 'open' };
+    const changes = diffJson(before, after, {
+      critical: ['status'],
+      ignore: ['summary']
+    });
+    expect(changes).toEqual([]);
+  });
+
+  it('captures array changes as critical when matched', () => {
+    const before = { benefits: [{ max_amount_cents: 1000 }] };
+    const after = { benefits: [{ max_amount_cents: 2000 }] };
+    const changes = diffJson(before, after, {
+      critical: ['benefits']
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ path: 'benefits', critical: true, kind: 'changed' });
+  });
+});
+
+describe('summarizeDiff', () => {
+  it('summarizes changed and critical paths', () => {
+    const changes = [
+      { path: 'status', kind: 'changed' as const, before: 'open', after: 'closed', critical: true },
+      { path: 'summary', kind: 'changed' as const, before: 'a', after: 'b', critical: false }
+    ];
+    const summary = summarizeDiff(changes);
+    expect(summary.totalChanges).toBe(2);
+    expect(summary.criticalChanges).toBe(1);
+    expect(summary.changedPaths).toContain('status');
+    expect(summary.criticalPaths).toEqual(['status']);
+  });
+});

--- a/apps/ingest/src/diff/json.ts
+++ b/apps/ingest/src/diff/json.ts
@@ -1,0 +1,205 @@
+export type DiffRule = string | RegExp;
+
+export type JsonDiffKind = 'added' | 'removed' | 'changed';
+
+export type JsonDiffChange = {
+  path: string;
+  kind: JsonDiffKind;
+  before?: unknown;
+  after?: unknown;
+  critical: boolean;
+};
+
+export type DiffOptions = {
+  ignore?: DiffRule[];
+  critical?: DiffRule[];
+};
+
+export type DiffSummary = {
+  totalChanges: number;
+  criticalChanges: number;
+  changedPaths: string[];
+  criticalPaths: string[];
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const normalizeRule = (rule: DiffRule): DiffRule => {
+  if (typeof rule === 'string') {
+    return rule.trim();
+  }
+  return rule;
+};
+
+const pathMatches = (path: string, rule: DiffRule): boolean => {
+  if (typeof rule === 'string') {
+    if (!rule) return false;
+    const normalizedPath = path.replace(/\.(\d+)/g, '.$1');
+    const wildcardPath = normalizedPath.replace(/\.\d+/g, '.*');
+    if (rule.endsWith('.*')) {
+      const prefix = rule.slice(0, -2);
+      return (
+        normalizedPath === prefix ||
+        normalizedPath.startsWith(`${prefix}.`) ||
+        wildcardPath.startsWith(`${prefix}.`)
+      );
+    }
+    if (rule.includes('*')) {
+      const ruleTokens = rule.split('.');
+      const pathTokens = normalizedPath.split('.');
+      if (ruleTokens.length !== pathTokens.length) return false;
+      return ruleTokens.every((token, idx) => token === '*' || token === pathTokens[idx]);
+    }
+    return normalizedPath === rule;
+  }
+  return rule.test(path);
+};
+
+const shouldIgnorePath = (path: string, options: DiffOptions): boolean => {
+  const rules = options.ignore ?? [];
+  return rules.some((rule) => pathMatches(path, normalizeRule(rule)));
+};
+
+const isCriticalPath = (path: string, options: DiffOptions): boolean => {
+  const rules = options.critical ?? [];
+  if (rules.length === 0) return false;
+  return rules.some((rule) => pathMatches(path, normalizeRule(rule)));
+};
+
+const collectObjectDiff = (
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  path: string,
+  options: DiffOptions,
+  changes: JsonDiffChange[]
+) => {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of keys) {
+    const nextPath = path ? `${path}.${key}` : key;
+    const left = before[key];
+    const right = after[key];
+    collectDiffInternal(left, right, nextPath, options, changes);
+  }
+};
+
+const collectArrayDiff = (
+  before: unknown[] | undefined,
+  after: unknown[] | undefined,
+  path: string,
+  options: DiffOptions,
+  changes: JsonDiffChange[]
+) => {
+  const left = before ?? [];
+  const right = after ?? [];
+  const sameLength = left.length === right.length;
+  const equal = sameLength && left.every((value, idx) => deepEqual(value, right[idx]));
+  if (equal) {
+    return;
+  }
+  const critical = isCriticalPath(path, options);
+  changes.push({
+    path,
+    kind: before === undefined ? 'added' : after === undefined ? 'removed' : 'changed',
+    before: before === undefined ? undefined : left,
+    after: after === undefined ? undefined : right,
+    critical
+  });
+};
+
+const collectDiffInternal = (
+  before: unknown,
+  after: unknown,
+  path: string,
+  options: DiffOptions,
+  changes: JsonDiffChange[]
+) => {
+  if (shouldIgnorePath(path, options)) {
+    return;
+  }
+  if (before === undefined && after === undefined) {
+    return;
+  }
+  if (Array.isArray(before) || Array.isArray(after)) {
+    collectArrayDiff(
+      Array.isArray(before) ? before : undefined,
+      Array.isArray(after) ? after : undefined,
+      path,
+      options,
+      changes
+    );
+    return;
+  }
+  if (isObject(before) && isObject(after)) {
+    collectObjectDiff(before, after, path, options, changes);
+    return;
+  }
+  if (before === undefined) {
+    const critical = isCriticalPath(path, options);
+    changes.push({ path, kind: 'added', after, critical });
+    return;
+  }
+  if (after === undefined) {
+    const critical = isCriticalPath(path, options);
+    changes.push({ path, kind: 'removed', before, critical });
+    return;
+  }
+  if (!deepEqual(before, after)) {
+    const critical = isCriticalPath(path, options);
+    changes.push({ path, kind: 'changed', before, after, critical });
+  }
+};
+
+export const diffJson = (before: unknown, after: unknown, options: DiffOptions = {}): JsonDiffChange[] => {
+  const changes: JsonDiffChange[] = [];
+  const left = before ?? {};
+  const right = after ?? {};
+  collectDiffInternal(left, right, '', options, changes);
+  return changes.sort((a, b) => a.path.localeCompare(b.path));
+};
+
+export const summarizeDiff = (changes: JsonDiffChange[]): DiffSummary => {
+  const changedPaths = new Set<string>();
+  const criticalPaths = new Set<string>();
+  let total = 0;
+  let critical = 0;
+  for (const change of changes) {
+    const topLevel = change.path.split('.')[0] ?? change.path;
+    if (topLevel) {
+      changedPaths.add(topLevel);
+      if (change.critical) {
+        criticalPaths.add(topLevel);
+      }
+    }
+    total += 1;
+    if (change.critical) {
+      critical += 1;
+    }
+  }
+  return {
+    totalChanges: total,
+    criticalChanges: critical,
+    changedPaths: Array.from(changedPaths).sort(),
+    criticalPaths: Array.from(criticalPaths).sort()
+  };
+};
+
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (isObject(a) && isObject(b)) {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    for (const key of keys) {
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+    return true;
+  }
+  return false;
+};

--- a/apps/ingest/src/enrich.ts
+++ b/apps/ingest/src/enrich.ts
@@ -86,7 +86,7 @@ async function loadSampleLookup(): Promise<NaicsEntry[]> {
 
 async function loadLookup(env: EnrichEnv): Promise<NaicsEntry[]> {
   const hasValidCache = lookupCache !== null && Date.now() - lookupCache.ts < CACHE_TTL_MS;
-  if (lookupCache && hasValidCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
+  if (hasValidCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
     return lookupCache.entries;
   }
 

--- a/apps/ingest/src/enrich.ts
+++ b/apps/ingest/src/enrich.ts
@@ -85,8 +85,8 @@ async function loadSampleLookup(): Promise<NaicsEntry[]> {
 }
 
 async function loadLookup(env: EnrichEnv): Promise<NaicsEntry[]> {
-  const hasValidCache = lookupCache && Date.now() - lookupCache.ts < CACHE_TTL_MS;
-  if (hasValidCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
+  const hasValidCache = lookupCache !== null && Date.now() - lookupCache.ts < CACHE_TTL_MS;
+  if (lookupCache && hasValidCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
     return lookupCache.entries;
   }
 
@@ -148,8 +148,8 @@ async function loadIndustryMappings(env: EnrichEnv): Promise<Map<string, Industr
   if (!env.DB) {
     return new Map();
   }
-  const hasValidCache = mappingCache && Date.now() - mappingCache.ts < CACHE_TTL_MS;
-  if (hasValidCache && mappingCacheStatus === 'ok') {
+  const hasValidCache = mappingCache !== null && Date.now() - mappingCache.ts < CACHE_TTL_MS;
+  if (mappingCache && hasValidCache && mappingCacheStatus === 'ok') {
     return mappingCache.entries;
   }
 
@@ -258,4 +258,11 @@ export async function enrichNaics(program: NormalizedProgram, env: EnrichEnv): P
     industry_codes: codeList,
     tags: mergedTags
   };
+}
+
+export function resetEnrichmentCaches(): void {
+  lookupCache = null;
+  lookupCacheSource = null;
+  mappingCache = null;
+  mappingCacheStatus = null;
 }

--- a/apps/ingest/src/enrich.ts
+++ b/apps/ingest/src/enrich.ts
@@ -149,7 +149,7 @@ async function loadIndustryMappings(env: EnrichEnv): Promise<Map<string, Industr
     return new Map();
   }
   const hasValidCache = mappingCache !== null && Date.now() - mappingCache.ts < CACHE_TTL_MS;
-  if (mappingCache && hasValidCache && mappingCacheStatus === 'ok') {
+  if (hasValidCache && mappingCacheStatus === 'ok') {
     return mappingCache.entries;
   }
 

--- a/apps/ingest/src/index.ts
+++ b/apps/ingest/src/index.ts
@@ -3,6 +3,7 @@ import type { D1Database } from '@cloudflare/workers-types';
 import { formatDay } from '@common/dates';
 
 import { runCatalogOnce } from './catalog';
+import { getIngestionMetricsAdapter } from './metrics';
 import { runOutbox } from './alerts.outbox';
 import { checkDeadlinks } from './deadlinks';
 import { writeDailyCoverage } from './precompute.coverage';
@@ -104,7 +105,9 @@ async function runDailyMetrics(env: IngestEnv, event: ScheduledEvent): Promise<v
 
 export default {
   async scheduled(event: ScheduledEvent, env: IngestEnv, _ctx: ExecutionContext) {
-    await runCatalogOnce(env);
+    await runCatalogOnce(env, new Date(), {
+      metricsAdapter: getIngestionMetricsAdapter(env as any)
+    });
 
     if (shouldRunOutbox(event)) {
       await runOutbox(env);

--- a/apps/ingest/src/metrics.ts
+++ b/apps/ingest/src/metrics.ts
@@ -1,0 +1,110 @@
+import type { UpsertOutcome, ProgramDiffRecord } from './upsert';
+
+export type RunStatus = 'ok' | 'error' | 'partial';
+
+export type ProgramDiffSample = {
+  uid: string;
+  diff: ProgramDiffRecord;
+};
+
+export type RunDiffSummary = {
+  totalProgramsChanged: number;
+  totalChanges: number;
+  criticalPrograms: number;
+  criticalChanges: number;
+  samples: ProgramDiffSample[];
+};
+
+export type IngestionRunStartEvent = {
+  sourceId: string;
+  sourceRowId: number;
+  runId: number | null;
+  startedAt: number;
+};
+
+export type IngestionRunCompleteEvent = {
+  sourceId: string;
+  sourceRowId: number;
+  runId: number | null;
+  status: RunStatus;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+  fetched: number;
+  inserted: number;
+  updated: number;
+  unchanged: number;
+  errors: number;
+  notes: string[];
+  diffSummary: RunDiffSummary;
+};
+
+export interface MetricsAdapter {
+  onRunStart?: (event: IngestionRunStartEvent) => void | Promise<void>;
+  onRunComplete?: (event: IngestionRunCompleteEvent) => void | Promise<void>;
+}
+
+const MAX_SAMPLES = 5;
+
+export const summarizeOutcomes = (outcomes: UpsertOutcome[]): RunDiffSummary => {
+  const samples: ProgramDiffSample[] = [];
+  let totalProgramsChanged = 0;
+  let totalChanges = 0;
+  let criticalPrograms = 0;
+  let criticalChanges = 0;
+
+  for (const outcome of outcomes) {
+    if (outcome.status === 'unchanged' || !outcome.diff) {
+      continue;
+    }
+    totalProgramsChanged += 1;
+    totalChanges += outcome.diff.summary.totalChanges;
+    criticalChanges += outcome.diff.summary.criticalChanges;
+    if (outcome.diff.summary.criticalChanges > 0) {
+      criticalPrograms += 1;
+    }
+    if (samples.length < MAX_SAMPLES) {
+      samples.push({ uid: outcome.uid, diff: outcome.diff });
+    }
+  }
+
+  return {
+    totalProgramsChanged,
+    totalChanges,
+    criticalPrograms,
+    criticalChanges,
+    samples
+  };
+};
+
+export const createConsoleMetricsAdapter = (): MetricsAdapter => ({
+  async onRunComplete(event) {
+    const payload = {
+      type: 'ingest_run',
+      sourceId: event.sourceId,
+      runId: event.runId,
+      status: event.status,
+      durationMs: event.durationMs,
+      fetched: event.fetched,
+      inserted: event.inserted,
+      updated: event.updated,
+      unchanged: event.unchanged,
+      errors: event.errors,
+      criticalChanges: event.diffSummary.criticalChanges,
+      totalChanges: event.diffSummary.totalChanges,
+      totalProgramsChanged: event.diffSummary.totalProgramsChanged,
+      notes: event.notes
+    };
+    console.log(JSON.stringify(payload));
+  }
+});
+
+export const noopMetricsAdapter: MetricsAdapter = {};
+
+export const getIngestionMetricsAdapter = (env: { METRICS_DISABLE?: string } | undefined): MetricsAdapter => {
+  const flag = env?.METRICS_DISABLE;
+  if (flag === '1' || flag === 'true') {
+    return noopMetricsAdapter;
+  }
+  return createConsoleMetricsAdapter();
+};

--- a/bun.lock
+++ b/bun.lock
@@ -10,20 +10,20 @@
         "currency.js": "^2.0.4",
         "date-fns": "^3.6.0",
         "drizzle-orm": "^0.30.10",
-        "hono": "^4.9.8",
+        "hono": "^4.9.9",
         "node-fetch": "^3.3.2",
         "otpauth": "^9.4.1",
         "zod": "^4.1.11",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250921.0",
-        "@types/node": "^24.5.2",
-        "bun-types": "^1.2.22",
+        "@types/node": "^24.6.1",
+        "bun-types": "^1.2.23",
         "node-gyp": "^9.4.1",
         "ts-to-openapi": "^1.3.0",
-        "typescript": "^5.9.2",
+        "typescript": "^5.9.3",
         "vitest": "^3.2.4",
-        "wrangler": "^4.40.2",
+        "wrangler": "^4.40.3",
       },
     },
   },
@@ -36,17 +36,17 @@
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
 
-    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.7.4", "", { "peerDependencies": { "unenv": "2.0.0-rc.21", "workerd": "^1.20250912.0" }, "optionalPeers": ["workerd"] }, "sha512-KIjbu/Dt50zseJIoOOK5y4eYpSojD9+xxkePYVK1Rg9k/p/st4YyMtz1Clju/zrenJHrOH+AAcjNArOPMwH4Bw=="],
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.7.5", "", { "peerDependencies": { "unenv": "2.0.0-rc.21", "workerd": "^1.20250924.0" }, "optionalPeers": ["workerd"] }, "sha512-eB3UAIVhrvY+CMZrRXS/bAv5kWdNiH+dgwu+1M1S7keDeonxkfKIGVIrhcCLTkcqYlN30MPURPuVFUEzIWuuvg=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250924.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-/+nWoNDIzdQaQib7MrWYEfeDt1vA40Ah68nXlZGXHonkIqJvkjaTP8dzdKZLuwnQokiV/SpnAXNMH0WGH31XMw=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250927.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rFtXu/qhZziGOltjhHUCdlqP9wLUhf/CmnjJS0hXffGRAVxsCXhJw+7Vlr+hyRSHjHRhEV+gBFc4pHzT10Stzw=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250924.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UAjC5mra+WNWy6jMbIDe9orsFmYvvMlfvZdUyn5p3NlQhhU6cc4FkFuXJ/bV+6oVw5hIhlLlFCTnsGatki/uHg=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250927.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BcNlLVfPyctLjFeIJENhK7OZFkfaysHVA6G6KT1lwum+BaVOutebweLo2zOrH7UQCMDYdpkQOeb5nLDctvs8YA=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250924.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IcwaoZFXGHq+yOBEj91QZH4qU61ws5upE7T43wVcrUAk8VXgxL12IGUVkMCEqfFXTO40PjKZBmK16B2q1HoFow=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250927.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3c+RuyMj3CkaFS9mmVJyX6nNUdTn2kdWgPrpPoj7VbtU2BEGkrH1a4VAgIAiUh/tYRGUeY3owrUhqCv6L7HmJQ=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250924.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-NgKG/cJiRNoJFa8QqweG0/bpkrUYKpR9mA9/qLJcGiwfvJrfK9b+ucw0lCru1BVMlyuS3kWDjagjMWqfujdBkA=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250927.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/XtcZnIryAgLvums08r5xiSm5hYfRfUuj2iq/5Jl+Yysx1BmPjYLqjcIIXNATrzpKUrxf3AkvpSI75MBcePgpA=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250924.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PntewemtjgLO2+8Gjw3G/NowDjpWZNKpKk/n4KmOQaWS9jIRq3IG1LkTqxj/BbMXqa4Oyrywk2kdqspj6QllOw=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250927.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+m124IiM149QvvzAOrO766uTdILqXJZqzZjqTaMTaWXegjjsJwGSL6v9d71TSFntEwxeXnpJPBkVWyKZFjqrvg=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250921.0", "", {}, "sha512-+UDLgnqSYdy1gezjhlZxRAx+tOW+Za8FYxuIMa7VnpgIlQnCL8937rb0uCt/YZuIJFE2T7OK5GvFQ3HeUAkeFQ=="],
 
@@ -220,7 +220,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@24.5.2", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ=="],
+    "@types/node": ["@types/node@24.6.1", "", { "dependencies": { "undici-types": "~7.13.0" } }, "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw=="],
 
     "@types/react": ["@types/react@19.1.13", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ=="],
 
@@ -278,7 +278,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.2.22", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-hwaAu8tct/Zn6Zft4U9BsZcXkYomzpHJX28ofvx7k0Zz2HNz54n1n+tDgxoWFGB4PcFvJXJQloPhaV2eP3Q6EA=="],
+    "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -444,7 +444,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.9.8", "", {}, "sha512-JW8Bb4RFWD9iOKxg5PbUarBYGM99IcxFl2FPBo2gSJO11jjUDqlP1Bmfyqt8Z/dGhIQ63PMA9LdcLefXyIasyg=="],
+    "hono": ["hono@4.9.9", "", {}, "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw=="],
 
     "htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
 
@@ -512,7 +512,7 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "miniflare": ["miniflare@4.20250924.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20250924.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-eQuWHklTeYYOil7sPPWo7Wrw86I4oac1kGAYfYcjg5dqMgMAiPUHvUWXMlTvW8ON6q33Ew23AsGDirm+Bea9ig=="],
+    "miniflare": ["miniflare@4.20250927.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20250927.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-CP0Q9Ytipid/Q6fJ2gAsVJ3yIMdx1+GoivA+EON68/ZLt66QwUFtpFeqdOUOKDmMbf/NFzjsKsce6h/8KjjYXg=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -688,13 +688,13 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
     "undici": ["undici@7.14.0", "", {}, "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ=="],
 
-    "undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
+    "undici-types": ["undici-types@7.13.0", "", {}, "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ=="],
 
     "unenv": ["unenv@2.0.0-rc.21", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.7", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A=="],
 
@@ -722,9 +722,9 @@
 
     "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
 
-    "workerd": ["workerd@1.20250924.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250924.0", "@cloudflare/workerd-darwin-arm64": "1.20250924.0", "@cloudflare/workerd-linux-64": "1.20250924.0", "@cloudflare/workerd-linux-arm64": "1.20250924.0", "@cloudflare/workerd-windows-64": "1.20250924.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-ovO2vwRCcMOlOm3bNwQQrVb8KDcewE/3rjfbZAYSF535BQQDUZ9dE1kyGBYlGx4W5udH3kqmOr+0YqTBLlycyA=="],
+    "workerd": ["workerd@1.20250927.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250927.0", "@cloudflare/workerd-darwin-arm64": "1.20250927.0", "@cloudflare/workerd-linux-64": "1.20250927.0", "@cloudflare/workerd-linux-arm64": "1.20250927.0", "@cloudflare/workerd-windows-64": "1.20250927.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-6kyAGPGYNvn5mbpCJJ48VebN7QGSrvU/WJXgd4EQz20PyqjJAxHcEGGAJ+0Da0u/ewrN1+6fuMKQ1ALLBPiTWg=="],
 
-    "wrangler": ["wrangler@4.40.2", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.7.4", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250924.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.21", "workerd": "1.20250924.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250924.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-wcev8GF6GU4ME5AsYY/gUehHrGdRiUCkifuyCeuVvpOtha3TMK4/s39x+jLuJBRtibpgejDekO68rqxfamf16A=="],
+    "wrangler": ["wrangler@4.40.3", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.7.5", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250927.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.21", "workerd": "1.20250927.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250927.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Ltf/0EwyJ9yJeWuCCGHOZDrGGMfZhVECUsJRbeBt1JTV2g7Ebw6FYrXOJhFEEfj1Mr51Cbt3nYI07TMyfxhPwA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 

--- a/docs/ingestion-observability.md
+++ b/docs/ingestion-observability.md
@@ -1,0 +1,71 @@
+# Ingestion Observability & Diffing
+
+This document explains how to monitor catalog ingestion runs, interpret diff records, and run the local CLI tooling added in Sprint 3.
+
+## Run lifecycle
+
+Each catalog dispatch writes a row to `ingestion_runs` capturing:
+
+- `source_id`, `started_at`, `ended_at`, and execution `status` (`ok`, `partial`, `error`).
+- Counters for `fetched`, `inserted`, `updated`, `unchanged`, and `errors`.
+- `critical` flag whenever a run produces critical content changes.
+- `notes` array with contextual messages (initialization issues, HTTP errors, etc.).
+
+The ingestion worker wraps each source with lifecycle hooks. Structured run summaries are emitted through the metrics adapter (console logging by default), and each run persists diffs via `program_diffs` and `snapshot_diffs`.
+
+### Program & snapshot diffs
+
+`upsertPrograms` normalizes every payload, compares it to the previous persisted snapshot, and records:
+
+- `program_diffs`: before/after snapshots, changed paths, and whether any critical fields (status, funding, dates) changed.
+- `snapshot_diffs`: links to raw payload snapshots when R2 storage is enabled, including references to the previous snapshot.
+
+Diffs use a JSON utility that ignores noisy fields (e.g., summaries) while flagging critical fields. Critical changes appear in both tables (`critical = 1`).
+
+## CLI usage
+
+Use the new Bun script to run the catalog once against a local SQLite database:
+
+```bash
+bun run ingest:once             # run all sources into data/ingest.dev.sqlite
+bun run ingest:once --source=us-fed-grants-gov --db=.data/custom.sqlite
+```
+
+The CLI applies all SQL migrations, executes the ingestion loop, and prints human-readable summaries:
+
+```
+✅ us-fed-grants-gov – fetched 12, inserted 5, updated 3, unchanged 4, errors 0
+   duration 1.24s; changed 8 program(s), 2 critical
+   • program-uid-1 (critical): status, end_date
+   • program-uid-2: benefits, tags
+```
+
+Notes appear when HTTP or adapter errors occur. The CLI disables structured metrics output to avoid duplicate console entries.
+
+## Alerting & dashboards
+
+The ingestion worker logs JSON payloads such as:
+
+```json
+{
+  "type": "ingest_run",
+  "sourceId": "us-fed-grants-gov",
+  "status": "ok",
+  "durationMs": 1240,
+  "fetched": 12,
+  "inserted": 5,
+  "updated": 3,
+  "unchanged": 4,
+  "errors": 0,
+  "criticalChanges": 2,
+  "totalChanges": 14,
+  "totalProgramsChanged": 8,
+  "notes": []
+}
+```
+
+These logs can be consumed by Cloudflare Logpush or Workers Analytics to create dashboards and alert on error or critical-change thresholds.
+
+## Testing
+
+Vitest covers the diff utility (`apps/ingest/src/diff/json.test.ts`) and catalog ingestion (`tests/ingest.catalog.test.ts`). Run `bun test` or `bun run typecheck` before deploying.

--- a/migrations/0013_ingest_diff_metrics.sql
+++ b/migrations/0013_ingest_diff_metrics.sql
@@ -1,0 +1,29 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE ingestion_runs ADD COLUMN critical INTEGER DEFAULT 0;
+ALTER TABLE ingestion_runs ADD COLUMN notes TEXT;
+
+ALTER TABLE program_diffs ADD COLUMN run_id INTEGER;
+ALTER TABLE program_diffs ADD COLUMN summary TEXT;
+ALTER TABLE program_diffs ADD COLUMN critical INTEGER DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_program_diffs_run ON program_diffs(run_id);
+
+CREATE TABLE IF NOT EXISTS snapshot_diffs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  program_uid TEXT NOT NULL,
+  snapshot_id INTEGER NOT NULL,
+  prev_snapshot_id INTEGER,
+  run_id INTEGER,
+  source_id INTEGER,
+  ts INTEGER NOT NULL,
+  diff TEXT NOT NULL,
+  critical INTEGER DEFAULT 0,
+  FOREIGN KEY (snapshot_id) REFERENCES snapshots(id) ON DELETE CASCADE,
+  FOREIGN KEY (prev_snapshot_id) REFERENCES snapshots(id) ON DELETE SET NULL,
+  FOREIGN KEY (run_id) REFERENCES ingestion_runs(id) ON DELETE SET NULL,
+  FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_diffs_program_time ON snapshot_diffs(program_uid, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_snapshot_diffs_run ON snapshot_diffs(run_id);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "deploy": "bun run scripts/deploy.ts",
     "typecheck": "bunx tsc -p tsconfig.json",
     "lint": "bun run typecheck",
-    "openapi": "bun run scripts/generate-openapi.ts"
+    "openapi": "bun run scripts/generate-openapi.ts",
+    "ingest:once": "bun run scripts/ingest-once.ts"
   },
   "dependencies": {
     "@cloudflare/d1": "^1.4.1",
@@ -25,19 +26,19 @@
     "currency.js": "^2.0.4",
     "date-fns": "^3.6.0",
     "drizzle-orm": "^0.30.10",
-    "hono": "^4.9.8",
+    "hono": "^4.9.9",
     "node-fetch": "^3.3.2",
     "otpauth": "^9.4.1",
     "zod": "^4.1.11"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250921.0",
-    "@types/node": "^24.5.2",
-    "bun-types": "^1.2.22",
+    "@types/node": "^24.6.1",
+    "bun-types": "^1.2.23",
+    "node-gyp": "^9.4.1",
     "ts-to-openapi": "^1.3.0",
-    "typescript": "^5.9.2",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4",
-    "wrangler": "^4.40.2",
-    "node-gyp": "^9.4.1"
+    "wrangler": "^4.40.3"
   }
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,64 @@
 import { sqliteTable, integer, text, index, uniqueIndex, real } from 'drizzle-orm/sqlite-core';
 
+export const ingestionRuns = sqliteTable(
+  'ingestion_runs',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    sourceId: integer('source_id').notNull(),
+    startedAt: integer('started_at').notNull(),
+    endedAt: integer('ended_at').notNull(),
+    status: text('status').notNull(),
+    fetched: integer('fetched').notNull().default(0),
+    inserted: integer('inserted').notNull().default(0),
+    updated: integer('updated').notNull().default(0),
+    unchanged: integer('unchanged').notNull().default(0),
+    errors: integer('errors').notNull().default(0),
+    critical: integer('critical', { mode: 'boolean' }).notNull().default(false),
+    message: text('message'),
+    notes: text('notes')
+  },
+  (table) => ({
+    sourceIdx: index('idx_ingestion_runs_source_time').on(table.sourceId, table.startedAt)
+  })
+);
+
+export const programDiffs = sqliteTable(
+  'program_diffs',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    programUid: text('program_uid').notNull(),
+    sourceId: integer('source_id'),
+    runId: integer('run_id'),
+    ts: integer('ts').notNull(),
+    diff: text('diff').notNull(),
+    summary: text('summary'),
+    critical: integer('critical', { mode: 'boolean' }).notNull().default(false)
+  },
+  (table) => ({
+    programIdx: index('idx_program_diffs_program_time').on(table.programUid, table.ts),
+    runIdx: index('idx_program_diffs_run').on(table.runId)
+  })
+);
+
+export const snapshotDiffs = sqliteTable(
+  'snapshot_diffs',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    programUid: text('program_uid').notNull(),
+    snapshotId: integer('snapshot_id').notNull(),
+    prevSnapshotId: integer('prev_snapshot_id'),
+    runId: integer('run_id'),
+    sourceId: integer('source_id'),
+    ts: integer('ts').notNull(),
+    diff: text('diff').notNull(),
+    critical: integer('critical', { mode: 'boolean' }).notNull().default(false)
+  },
+  (table) => ({
+    programIdx: index('idx_snapshot_diffs_program_time').on(table.programUid, table.ts),
+    runIdx: index('idx_snapshot_diffs_run').on(table.runId)
+  })
+);
+
 export const programs = sqliteTable('programs', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   uid: text('uid').notNull().unique(),                                     // stable deterministic id

--- a/scripts/ingest-once.ts
+++ b/scripts/ingest-once.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env bun
+import { mkdirSync, existsSync, readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+
+import { runCatalogOnce } from '../apps/ingest/src/catalog';
+import { noopMetricsAdapter } from '../apps/ingest/src/metrics';
+
+type Prepared = {
+  bind: (...values: any[]) => Prepared;
+  first: <T = any>() => Promise<T | null>;
+  run: () => Promise<{ success: boolean; meta: { changes: number; duration: number; last_row_id: number } }>;
+  all: <T = any>() => Promise<{ results: T[] }>;
+};
+
+type D1Like = D1Database & { close: () => void };
+
+type CliOptions = {
+  sources: string[];
+  dbPath: string;
+};
+
+async function getSqliteConstructor(): Promise<any> {
+  try {
+    const mod = await import('bun:sqlite');
+    return mod.Database;
+  } catch {
+    const mod = await import('better-sqlite3');
+    return mod.default;
+  }
+}
+
+function createPreparedStatement(stmt: any, params: any[] = []): Prepared {
+  return {
+    bind: (...values: any[]) => createPreparedStatement(stmt, values),
+    first: async <T = any>() => {
+      try {
+        const row = stmt.get(...params);
+        return (row ?? null) as T | null;
+      } catch {
+        return null;
+      }
+    },
+    run: async () => {
+      const info = stmt.run(...params);
+      return {
+        success: true,
+        meta: {
+          changes: Number(info?.changes ?? 0),
+          duration: 0,
+          last_row_id: Number(info?.lastInsertRowid ?? 0)
+        }
+      };
+    },
+    all: async <T = any>() => {
+      const rows = stmt.all(...params);
+      return { results: (rows ?? []) as T[] };
+    }
+  };
+}
+
+async function createLocalD1(path: string): Promise<D1Like> {
+  const Sqlite = await getSqliteConstructor();
+  mkdirSync(dirname(path), { recursive: true });
+  const sqlite = new Sqlite(path);
+  sqlite.exec('PRAGMA foreign_keys = ON;');
+
+  const db: any = {
+    prepare(sql: string) {
+      const stmt = sqlite.prepare(sql);
+      return createPreparedStatement(stmt);
+    },
+    async batch(statements: Prepared[]) {
+      const results = [];
+      for (const stmt of statements) {
+        results.push(await stmt.run());
+      }
+      return results;
+    },
+    async exec(sql: string) {
+      sqlite.exec(sql);
+      return { success: true };
+    },
+    close() {
+      if (typeof sqlite.close === 'function') {
+        sqlite.close();
+      }
+    }
+  };
+
+  return db as D1Like;
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const sources: string[] = [];
+  let dbPath = resolve(process.cwd(), 'data', 'ingest.dev.sqlite');
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--source' && args[i + 1]) {
+      sources.push(args[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--source=')) {
+      const value = arg.split('=')[1] ?? '';
+      if (value) {
+        value.split(',').map((token) => token.trim()).filter(Boolean).forEach((token) => sources.push(token));
+      }
+      continue;
+    }
+    if (arg === '--db' && args[i + 1]) {
+      dbPath = resolve(process.cwd(), args[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--db=')) {
+      const value = arg.split('=')[1] ?? '';
+      if (value) {
+        dbPath = resolve(process.cwd(), value);
+      }
+      continue;
+    }
+  }
+
+  return { sources, dbPath };
+}
+
+async function applyMigrations(db: D1Like) {
+  const migrationsDir = resolve(process.cwd(), 'migrations');
+  if (!existsSync(migrationsDir)) {
+    return;
+  }
+  const files = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+  for (const file of files) {
+    const sql = readFileSync(join(migrationsDir, file), 'utf8');
+    await db.exec(sql);
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(2)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}m ${remainder.toFixed(1)}s`;
+}
+
+function formatSummary(result: Awaited<ReturnType<typeof runCatalogOnce>>[number]): string {
+  const statusIcon = result.status === 'ok' ? '✅' : result.status === 'partial' ? '⚠️' : '❌';
+  const diff = result.diffSummary;
+  const criticalNote = diff.criticalPrograms > 0 ? `, ${diff.criticalPrograms} critical` : '';
+  return [
+    `${statusIcon} ${result.source.id} – fetched ${result.fetched}, inserted ${result.inserted}, updated ${result.updated}, unchanged ${result.unchanged}, errors ${result.errors}`,
+    `   duration ${formatDuration(result.durationMs)}; changed ${diff.totalProgramsChanged} program(s)${criticalNote}`
+  ].join('\n');
+}
+
+function formatSamples(result: Awaited<ReturnType<typeof runCatalogOnce>>[number]): string {
+  const samples = result.diffSummary.samples;
+  if (samples.length === 0) {
+    return '   No diff samples available.';
+  }
+  const lines: string[] = [];
+  for (const sample of samples) {
+    const critical = sample.diff.summary.criticalChanges > 0 ? ' (critical)' : '';
+    const fields = sample.diff.summary.changedPaths.slice(0, 5).join(', ') || 'unknown fields';
+    lines.push(`   • ${sample.uid}${critical}: ${fields}`);
+  }
+  return lines.join('\n');
+}
+
+async function main() {
+  const options = parseArgs();
+  const db = await createLocalD1(options.dbPath);
+  try {
+    await applyMigrations(db);
+    const results = await runCatalogOnce(
+      { DB: db } as any,
+      new Date(),
+      {
+        sourceIds: options.sources.length > 0 ? options.sources : undefined,
+        metricsAdapter: noopMetricsAdapter
+      }
+    );
+
+    if (results.length === 0) {
+      console.log('No sources matched the provided filters.');
+      return;
+    }
+
+    for (const result of results) {
+      console.log(formatSummary(result));
+      if (result.notes.length > 0) {
+        console.log(`   Notes: ${result.notes.join('; ')}`);
+      }
+      console.log(formatSamples(result));
+      console.log('');
+    }
+  } finally {
+    db.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('ingest:once failed', error);
+  process.exitCode = 1;
+});

--- a/scripts/types/better-sqlite3.d.ts
+++ b/scripts/types/better-sqlite3.d.ts
@@ -1,0 +1,1 @@
+declare module 'better-sqlite3';

--- a/tests/coverage.integration.test.ts
+++ b/tests/coverage.integration.test.ts
@@ -3,6 +3,7 @@ import type { D1Database, KVNamespace } from '@cloudflare/workers-types';
 
 import { buildCoverageResponse } from '../apps/api/src/coverage';
 import { runEnrichmentBackfill } from '../apps/ingest/src/backfill.enrichment';
+import { resetEnrichmentCaches } from '../apps/ingest/src/enrich';
 import { writeDailyCoverage } from '../apps/ingest/src/precompute.coverage';
 import { createTestDB } from './helpers/d1';
 
@@ -234,6 +235,7 @@ describe('coverage integration flow', () => {
     db = createTestDB();
     await createSchema(db);
     await seedFixtures(db, COVERAGE_TIME.getTime());
+    resetEnrichmentCaches();
   });
 
   afterEach(() => {

--- a/tests/enrich.naics.test.ts
+++ b/tests/enrich.naics.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 import type { KVNamespace } from '@cloudflare/workers-types';
-import { enrichNaics } from '../apps/ingest/src/enrich';
+import { enrichNaics, resetEnrichmentCaches } from '../apps/ingest/src/enrich';
 
 const mockKV = (data: any) => ({
   async get(_key: string) {
@@ -19,6 +19,10 @@ const mockDb = (rows: any[]) => ({
 });
 
 describe('enrichNaics', () => {
+  beforeEach(() => {
+    resetEnrichmentCaches();
+  });
+
   it('assigns NAICS codes from lookup synonyms', async () => {
     const env = { LOOKUPS_KV: mockKV([{ code: '111110', synonyms: ['agriculture'] }]) };
     const program = {


### PR DESCRIPTION
## Summary
- track ingestion run lifecycle data, persist program and snapshot diffs, and emit structured metrics
- add JSON diff utilities, schema changes, and CLI tooling for local ingest runs
- document observability workflows and expand test coverage for diffing and catalog runs

## Testing
- bun test apps/ingest/src/diff/json.test.ts
- bun test tests/ingest.catalog.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc6c69495c8327858d9e0129551632