### PR TITLE
feat: add auth lifecycle tests and session rotation support

### DIFF
--- a/apps/api/src/onboarding/email.ts
+++ b/apps/api/src/onboarding/email.ts
@@ -68,3 +68,28 @@ export function buildDecisionResultEmail(options: {
 
   return { to: recipient, subject, html } satisfies EmailPayload;
 }
+
+export function buildSignupEmail(options: {
+  recipient: string;
+  token: string;
+  activationBaseUrl: string;
+  expiresAt: string;
+}) {
+  const activationUrl = new URL(options.activationBaseUrl);
+  activationUrl.searchParams.set('token', options.token);
+  const expiresAt = new Date(options.expiresAt).toUTCString();
+  const html = `
+    <p>Your fungiagricap canvas account is ready.</p>
+    <p>
+      <a href="${activationUrl.toString()}">Activate your account</a> before <strong>${expiresAt}</strong> to set your password.
+    </p>
+    <p>If the button does not work, copy and paste this link into your browser:<br />${activationUrl.toString()}</p>
+  `;
+  const text = `Your fungiagricap canvas account is ready. Activate your account before ${expiresAt} by visiting ${activationUrl.toString()}`;
+  return {
+    to: options.recipient,
+    subject: 'Activate your fungiagricap account',
+    html,
+    text,
+  } satisfies EmailPayload;
+}

--- a/apps/api/src/security/auth.ts
+++ b/apps/api/src/security/auth.ts
@@ -1,0 +1,430 @@
+import { schemaVersion, userProfileSchema } from '../schemas';
+import type { Env } from '../db';
+import {
+  createEmailToken,
+  createSession,
+  deleteSession,
+  getEmailToken,
+  getSession,
+  getSessionWithSecrets,
+  markEmailTokenUsed,
+  rotateSession,
+} from '../onboarding/storage';
+import { hashPassword, verifyPassword } from './password';
+import { createTotpSecret, verifyTotpToken } from './totp';
+import { mfaMethodSchema } from '../schemas';
+import type { UserProfile } from '../schemas';
+
+const encoder = new TextEncoder();
+
+function toHex(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  return Array.from(view, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function parseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function randomToken(bytes = 32): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return toHex(buf);
+}
+
+async function hashToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(token));
+  return toHex(digest);
+}
+
+type UserRow = {
+  id: string;
+  email: string;
+  display_name: string;
+  status: string;
+  apps: string;
+  roles: string;
+  password_hash: string | null;
+  mfa_enrolled: number;
+  last_login_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type MfaMethodRow = {
+  id: string;
+  user_id: string;
+  type: string;
+  secret: string | null;
+  verified_at: string | null;
+  created_at: string;
+};
+
+type InternalMfaMethod = {
+  id: string;
+  type: 'totp' | 'webauthn';
+  secret: string | null;
+  verified_at: string | null;
+};
+
+type LoadedUser = {
+  profile: UserProfile;
+  passwordHash: string | null;
+  methods: InternalMfaMethod[];
+};
+
+function normaliseApps(raw: string): { website: boolean; program: boolean; canvas: boolean } {
+  const parsed = parseJson(raw, {} as Record<string, unknown>);
+  return {
+    website: Boolean(parsed.website),
+    program: Boolean(parsed.program ?? true),
+    canvas: Boolean(parsed.canvas ?? true),
+  };
+}
+
+function normaliseRoles(raw: string): string[] {
+  const parsed = parseJson(raw, [] as string[]);
+  return Array.isArray(parsed) ? parsed.map((value) => String(value)) : [];
+}
+
+function mapMethods(rows: MfaMethodRow[]): InternalMfaMethod[] {
+  return rows.map((row) => ({
+    id: row.id,
+    type: row.type === 'totp' ? 'totp' : 'webauthn',
+    secret: row.secret,
+    verified_at: row.verified_at,
+  }));
+}
+
+function buildProfile(row: UserRow, methods: InternalMfaMethod[]): UserProfile {
+  const publicMethods = methods.map((method) =>
+    mfaMethodSchema.parse({ id: method.id, type: method.type, verified_at: method.verified_at ?? null })
+  );
+  return userProfileSchema.parse({
+    schema_version: schemaVersion.value,
+    id: row.id,
+    email: row.email,
+    display_name: row.display_name,
+    status: row.status as UserProfile['status'],
+    apps: normaliseApps(row.apps),
+    roles: normaliseRoles(row.roles),
+    mfa_enrolled: Boolean(row.mfa_enrolled),
+    mfa_methods: publicMethods,
+    last_login_at: row.last_login_at ?? null,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  });
+}
+
+async function loadUserByEmail(env: Env, email: string): Promise<LoadedUser | null> {
+  const row = await env.DB.prepare(`SELECT * FROM users WHERE email = ?1`).bind(email.toLowerCase()).first<UserRow>();
+  if (!row) return null;
+  const methods = await env.DB.prepare(`SELECT * FROM mfa_methods WHERE user_id = ?1`).bind(row.id).all<MfaMethodRow>();
+  const mapped = mapMethods(methods.results ?? []);
+  return {
+    profile: buildProfile(row, mapped),
+    passwordHash: row.password_hash,
+    methods: mapped,
+  };
+}
+
+async function loadUserById(env: Env, id: string): Promise<LoadedUser | null> {
+  const row = await env.DB.prepare(`SELECT * FROM users WHERE id = ?1`).bind(id).first<UserRow>();
+  if (!row) return null;
+  const methods = await env.DB.prepare(`SELECT * FROM mfa_methods WHERE user_id = ?1`).bind(row.id).all<MfaMethodRow>();
+  const mapped = mapMethods(methods.results ?? []);
+  return {
+    profile: buildProfile(row, mapped),
+    passwordHash: row.password_hash,
+    methods: mapped,
+  };
+}
+
+async function updateUserPassword(env: Env, userId: string, passwordHash: string): Promise<void> {
+  const ts = new Date().toISOString();
+  await env.DB.prepare(`UPDATE users SET password_hash = ?1, status = 'active', updated_at = ?2 WHERE id = ?3`)
+    .bind(passwordHash, ts, userId)
+    .run();
+}
+
+async function setUserMfaEnrollment(env: Env, userId: string, enrolled: boolean): Promise<void> {
+  await env.DB.prepare(`UPDATE users SET mfa_enrolled = ?1, updated_at = ?2 WHERE id = ?3`)
+    .bind(enrolled ? 1 : 0, new Date().toISOString(), userId)
+    .run();
+}
+
+async function recordLogin(env: Env, userId: string): Promise<void> {
+  const ts = new Date().toISOString();
+  await env.DB.prepare(`UPDATE users SET last_login_at = ?1, updated_at = ?1 WHERE id = ?2`).bind(ts, userId).run();
+}
+
+type IssueSessionOptions = { mfaRequired: boolean; ip?: string; userAgent?: string };
+
+type SessionData = Awaited<ReturnType<typeof createSession>>;
+
+type IssuedSession = {
+  session: SessionData;
+  refreshToken: string;
+  refreshExpiresAt: string;
+};
+
+async function issueSession(env: Env, userId: string, options: IssueSessionOptions): Promise<IssuedSession> {
+  const refreshToken = randomToken();
+  const refreshHash = await hashToken(refreshToken);
+  const refreshExpiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString();
+  const session = await createSession(env, userId, {
+    mfaRequired: options.mfaRequired,
+    ip: options.ip,
+    userAgent: options.userAgent,
+    refreshTokenHash: refreshHash,
+    refreshExpiresAt,
+  });
+  return { session, refreshToken, refreshExpiresAt };
+}
+
+function isStrongPassword(password: string): boolean {
+  if (password.length < 12) return false;
+  if (!/[a-z]/.test(password)) return false;
+  if (!/[A-Z]/.test(password)) return false;
+  if (!/[0-9]/.test(password)) return false;
+  if (!/[^A-Za-z0-9]/.test(password)) return false;
+  return true;
+}
+
+export type AuthSuccess = {
+  status: 'ok';
+  user: UserProfile;
+  session: SessionData;
+  refresh_token: string;
+  refresh_expires_at: string;
+};
+
+export type MfaChallenge = {
+  status: 'mfa-required';
+  challenge_id: string;
+  expires_at: string;
+  methods: Array<'totp' | 'webauthn'>;
+};
+
+export type LoginResult = AuthSuccess | MfaChallenge;
+
+export async function acceptInvite(
+  env: Env,
+  params: { token: string; password: string; ip?: string; userAgent?: string }
+): Promise<AuthSuccess> {
+  if (!isStrongPassword(params.password)) {
+    throw new Error('weak_password');
+  }
+  const record = await getEmailToken(env, params.token, 'signup');
+  if (!record || !record.user_id) {
+    throw new Error('invalid_token');
+  }
+  const user = await loadUserById(env, record.user_id);
+  if (!user) {
+    throw new Error('user_not_found');
+  }
+  const passwordHash = await hashPassword(params.password);
+  await updateUserPassword(env, record.user_id, passwordHash);
+  await markEmailTokenUsed(env, record.id);
+  const issued = await issueSession(env, record.user_id, { mfaRequired: false, ip: params.ip, userAgent: params.userAgent });
+  await recordLogin(env, record.user_id);
+  const refreshedUser = await loadUserById(env, record.user_id);
+  if (!refreshedUser) {
+    throw new Error('user_not_found');
+  }
+  return {
+    status: 'ok',
+    user: refreshedUser.profile,
+    session: issued.session,
+    refresh_token: issued.refreshToken,
+    refresh_expires_at: issued.refreshExpiresAt,
+  };
+}
+
+function hasVerifiedTotp(methods: InternalMfaMethod[]): InternalMfaMethod | null {
+  return methods.find((method) => method.type === 'totp' && Boolean(method.verified_at) && method.secret) ?? null;
+}
+
+export async function login(
+  env: Env,
+  params: { email: string; password: string; totpCode?: string; ip?: string; userAgent?: string }
+): Promise<LoginResult> {
+  const user = await loadUserByEmail(env, params.email);
+  if (!user || !user.passwordHash) {
+    throw new Error('invalid_credentials');
+  }
+  const passwordOk = await verifyPassword(params.password, user.passwordHash);
+  if (!passwordOk) {
+    throw new Error('invalid_credentials');
+  }
+  if (user.profile.status !== 'active') {
+    throw new Error('inactive_user');
+  }
+  const verifiedTotp = hasVerifiedTotp(user.methods);
+  if (verifiedTotp && user.profile.mfa_enrolled) {
+    if (!params.totpCode) {
+      const expiresAt = new Date(Date.now() + 1000 * 60 * 5).toISOString();
+      const challenge = await createEmailToken(env, {
+        purpose: 'mfa-challenge',
+        userId: user.profile.id,
+        expiresAt,
+      });
+      return {
+        status: 'mfa-required',
+        challenge_id: challenge.token,
+        expires_at: challenge.expiresAt,
+        methods: ['totp'],
+      };
+    }
+    if (!verifyTotpToken(verifiedTotp.secret ?? '', params.totpCode)) {
+      throw new Error('invalid_mfa');
+    }
+  }
+  const issued = await issueSession(env, user.profile.id, {
+    mfaRequired: Boolean(verifiedTotp && user.profile.mfa_enrolled && !params.totpCode),
+    ip: params.ip,
+    userAgent: params.userAgent,
+  });
+  await recordLogin(env, user.profile.id);
+  const refreshed = await loadUserById(env, user.profile.id);
+  if (!refreshed) {
+    throw new Error('user_not_found');
+  }
+  return {
+    status: 'ok',
+    user: refreshed.profile,
+    session: issued.session,
+    refresh_token: issued.refreshToken,
+    refresh_expires_at: issued.refreshExpiresAt,
+  };
+}
+
+export async function verifyMfaChallenge(
+  env: Env,
+  params: { challengeId: string; code: string; ip?: string; userAgent?: string }
+): Promise<AuthSuccess> {
+  const token = await getEmailToken(env, params.challengeId, 'mfa-challenge');
+  if (!token || !token.user_id) {
+    throw new Error('invalid_challenge');
+  }
+  const user = await loadUserById(env, token.user_id);
+  if (!user) {
+    throw new Error('user_not_found');
+  }
+  const totp = hasVerifiedTotp(user.methods);
+  if (!totp || !totp.secret) {
+    throw new Error('mfa_not_configured');
+  }
+  if (!verifyTotpToken(totp.secret, params.code)) {
+    throw new Error('invalid_mfa');
+  }
+  await markEmailTokenUsed(env, token.id);
+  const issued = await issueSession(env, user.profile.id, { mfaRequired: false, ip: params.ip, userAgent: params.userAgent });
+  await recordLogin(env, user.profile.id);
+  const refreshed = await loadUserById(env, user.profile.id);
+  if (!refreshed) {
+    throw new Error('user_not_found');
+  }
+  return {
+    status: 'ok',
+    user: refreshed.profile,
+    session: issued.session,
+    refresh_token: issued.refreshToken,
+    refresh_expires_at: issued.refreshExpiresAt,
+  };
+}
+
+export async function startTotpEnrollment(env: Env, userId: string) {
+  const user = await loadUserById(env, userId);
+  if (!user) {
+    throw new Error('user_not_found');
+  }
+  await env.DB.prepare(`DELETE FROM mfa_methods WHERE user_id = ?1 AND type = 'totp' AND verified_at IS NULL`).bind(userId).run();
+  const secret = createTotpSecret(user.profile.email);
+  const methodId = `mfa_${crypto.randomUUID()}`;
+  const createdAt = new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO mfa_methods (id, user_id, type, secret, verified_at, created_at) VALUES (?1, ?2, 'totp', ?3, NULL, ?4)`
+  )
+    .bind(methodId, userId, secret.secret, createdAt)
+    .run();
+  await setUserMfaEnrollment(env, userId, false);
+  return { method_id: methodId, secret: secret.secret, otpauth_url: secret.uri };
+}
+
+export async function confirmTotpEnrollment(env: Env, params: { userId: string; methodId: string; code: string }) {
+  const method = await env.DB.prepare(`SELECT * FROM mfa_methods WHERE id = ?1 AND user_id = ?2`)
+    .bind(params.methodId, params.userId)
+    .first<MfaMethodRow>();
+  if (!method || method.type !== 'totp' || !method.secret) {
+    throw new Error('invalid_method');
+  }
+  if (!verifyTotpToken(method.secret, params.code)) {
+    throw new Error('invalid_mfa');
+  }
+  const nowIso = new Date().toISOString();
+  await env.DB.prepare(`UPDATE mfa_methods SET verified_at = ?1 WHERE id = ?2`).bind(nowIso, method.id).run();
+  await setUserMfaEnrollment(env, params.userId, true);
+  const user = await loadUserById(env, params.userId);
+  if (!user) {
+    throw new Error('user_not_found');
+  }
+  return user.profile;
+}
+
+export async function refreshSession(
+  env: Env,
+  params: { sessionId: string; refreshToken: string; ip?: string; userAgent?: string }
+): Promise<AuthSuccess> {
+  const stored = await getSessionWithSecrets(env, params.sessionId);
+  if (!stored || !stored.refreshTokenHash) {
+    throw new Error('invalid_session');
+  }
+  const session = stored.session;
+  if (!session.refresh_expires_at) {
+    throw new Error('invalid_session');
+  }
+  const expiresAtTs = Date.parse(session.refresh_expires_at);
+  if (Number.isFinite(expiresAtTs) && expiresAtTs < Date.now()) {
+    await deleteSession(env, session.id);
+    throw new Error('expired_refresh');
+  }
+  const providedHash = await hashToken(params.refreshToken);
+  if (providedHash !== stored.refreshTokenHash) {
+    await deleteSession(env, session.id);
+    throw new Error('invalid_refresh');
+  }
+  const issuedAt = new Date().toISOString();
+  const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 8).toISOString();
+  const refreshToken = randomToken();
+  const refreshExpiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString();
+  const refreshHash = await hashToken(refreshToken);
+  await rotateSession(env, session.id, {
+    issuedAt,
+    expiresAt,
+    refreshTokenHash: refreshHash,
+    refreshExpiresAt,
+    ip: params.ip,
+    userAgent: params.userAgent,
+  });
+  const latest = await getSession(env, session.id);
+  if (!latest) {
+    throw new Error('invalid_session');
+  }
+  const user = await loadUserById(env, latest.user_id);
+  if (!user) {
+    throw new Error('user_not_found');
+  }
+  return {
+    status: 'ok',
+    user: user.profile,
+    session: { ...latest, mfa_required: latest.mfa_required },
+    refresh_token: refreshToken,
+    refresh_expires_at: refreshExpiresAt,
+  };
+}

--- a/apps/ingest/src/enrich.ts
+++ b/apps/ingest/src/enrich.ts
@@ -86,7 +86,7 @@ async function loadSampleLookup(): Promise<NaicsEntry[]> {
 
 async function loadLookup(env: EnrichEnv): Promise<NaicsEntry[]> {
   const hasValidCache = lookupCache !== null && Date.now() - lookupCache.ts < CACHE_TTL_MS;
-  if (hasValidCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
+  if (hasValidCache && lookupCache && (!env.LOOKUPS_KV || lookupCacheSource === 'kv')) {
     return lookupCache.entries;
   }
 
@@ -149,7 +149,7 @@ async function loadIndustryMappings(env: EnrichEnv): Promise<Map<string, Industr
     return new Map();
   }
   const hasValidCache = mappingCache !== null && Date.now() - mappingCache.ts < CACHE_TTL_MS;
-  if (hasValidCache && mappingCacheStatus === 'ok') {
+  if (hasValidCache && mappingCache && mappingCacheStatus === 'ok') {
     return mappingCache.entries;
   }
 

--- a/docs/admin-runbooks.md
+++ b/docs/admin-runbooks.md
@@ -1,0 +1,21 @@
+# Admin Runbooks: Account & Canvas Operations
+
+## Approving Account Requests
+1. Navigate to the Cloudflare Worker admin decision console at `/admin/account/decision`.
+2. Verify the requester context (email, justification, requested apps).
+3. Approve via the generated decision token link; this will automatically:
+   - Update the `account_requests` row to `approved`.
+   - Provision the user profile and default “Lean Canvas Quickstart” canvas.
+   - Issue a one-time signup token (24 hour TTL) and dispatch both the approval and activation emails.
+4. Confirm the onboarding email landed by checking Cloudflare Email Routing logs or worker logs for `Email send requested` entries.
+
+## Revoking Sessions & Refresh Tokens
+1. Look up the session ID via the admin metrics console or database tooling.
+2. Call `POST /v1/auth/logout` (planned) or directly delete the session row in D1: `DELETE FROM sessions WHERE id = ?`.
+3. Our refresh rotation helper removes stale sessions automatically if an invalid refresh token is presented. You can also proactively expire a session by setting `refresh_expires_at` to a past timestamp and forcing clients to reauthenticate.
+4. When investigating compromised accounts, clear all sessions for the user (`DELETE FROM sessions WHERE user_id = ?`) and issue a password reset token with `purpose = 'signup'`.
+
+## Archiving Canvases
+1. Use the authenticated Canvas API (`PATCH /v1/canvases/:id`) with `{ "status": "archived" }` and the latest `revision` to avoid conflicts.
+2. Each mutation records a new `canvas_versions` entry. Validate via `GET /v1/canvases/:id/versions` that the revision advanced and the diff references the expected base revision.
+3. Archived canvases remain available for audit but are hidden from active dashboards; unarchive by PATCHing back to `status: "active"`.

--- a/migrations/0011_session_refresh.sql
+++ b/migrations/0011_session_refresh.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sessions ADD COLUMN refresh_expires_at TEXT;
+UPDATE sessions SET refresh_expires_at = created_at WHERE refresh_expires_at IS NULL;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -210,6 +210,7 @@ export const sessions = sqliteTable('sessions', {
   userId: text('user_id').notNull(),
   issuedAt: text('issued_at').notNull(),
   expiresAt: text('expires_at').notNull(),
+  refreshExpiresAt: text('refresh_expires_at'),
   mfaRequired: integer('mfa_required', { mode: 'boolean' }).notNull().default(false),
   ip: text('ip'),
   userAgent: text('user_agent'),

--- a/tests/auth.canvas.e2e.test.ts
+++ b/tests/auth.canvas.e2e.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest';
+import { TOTP } from 'otpauth';
+import { createTestDB } from './helpers/d1';
+import {
+  createAccountRequest,
+  updateAccountRequestStatus,
+  ensureUserWithDefaultCanvas,
+  createSignupToken,
+  getEmailToken,
+  listCanvases,
+  listCanvasVersions,
+  saveCanvas,
+  createCanvas,
+  createEmailToken,
+} from '../apps/api/src/onboarding/storage';
+import {
+  acceptInvite,
+  login,
+  verifyMfaChallenge,
+  startTotpEnrollment,
+  confirmTotpEnrollment,
+  refreshSession,
+} from '../apps/api/src/security/auth';
+import { buildDecisionEmail, buildSignupEmail } from '../apps/api/src/onboarding/email';
+
+const schema = `
+PRAGMA foreign_keys=ON;
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  apps TEXT NOT NULL,
+  roles TEXT NOT NULL DEFAULT '[]',
+  password_hash TEXT,
+  mfa_enrolled INTEGER NOT NULL DEFAULT 0,
+  last_login_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE TABLE mfa_methods (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  secret TEXT,
+  verified_at TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE TABLE account_requests (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  requested_apps TEXT NOT NULL,
+  justification TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  decided_at TEXT,
+  reviewer_id TEXT,
+  reviewer_comment TEXT
+);
+CREATE TABLE email_tokens (
+  id TEXT PRIMARY KEY,
+  token TEXT NOT NULL UNIQUE,
+  purpose TEXT NOT NULL,
+  user_id TEXT,
+  account_request_id TEXT,
+  expires_at TEXT NOT NULL,
+  used_at TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (account_request_id) REFERENCES account_requests(id) ON DELETE CASCADE
+);
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  issued_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  refresh_expires_at TEXT,
+  mfa_required INTEGER NOT NULL DEFAULT 0,
+  ip TEXT,
+  user_agent TEXT,
+  refresh_token_hash TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE TABLE canvases (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  summary TEXT,
+  content TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE TABLE canvas_versions (
+  id TEXT PRIMARY KEY,
+  canvas_id TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  content TEXT NOT NULL,
+  diff TEXT,
+  created_at TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  FOREIGN KEY (canvas_id) REFERENCES canvases(id) ON DELETE CASCADE
+);
+`;
+
+describe('account onboarding, auth, and canvas lifecycle', () => {
+  it('handles invite acceptance, MFA enrolment, session refresh, and canvas versioning', async () => {
+    const db = createTestDB();
+    await db.exec(schema);
+    const env = { DB: db } as any;
+
+    const requestedApps = { website: false, program: true, canvas: true };
+    const account = await createAccountRequest(env, {
+      email: 'founder@example.com',
+      displayName: 'Founders Inc',
+      requestedApps,
+      justification: 'Exploring canvas workflows',
+    });
+    expect(account.accountRequest.status).toBe('pending');
+
+    const approval = await updateAccountRequestStatus(
+      env,
+      account.accountRequest.id,
+      'approved',
+      'admin',
+      'Looks great'
+    );
+    expect(approval?.status).toBe('approved');
+
+    const userId = await ensureUserWithDefaultCanvas(env, {
+      id: 'user_invitee',
+      email: 'founder@example.com',
+      display_name: 'Founders Inc',
+      status: 'active',
+      apps: requestedApps,
+      roles: ['user'],
+      mfa_enrolled: false,
+    });
+
+    const invite = await createSignupToken(env, userId, 24);
+    const inviteEmail = buildSignupEmail({
+      recipient: 'founder@example.com',
+      token: invite.token,
+      activationBaseUrl: 'https://program.fungiagricap.com/account/activate',
+      expiresAt: invite.expiresAt,
+    });
+    expect(inviteEmail.subject).toContain('Activate');
+    expect(inviteEmail.html).toContain(invite.token);
+
+    const accepted = await acceptInvite(env, {
+      token: invite.token,
+      password: 'Sup3rSecure!PW',
+      ip: '203.0.113.10',
+      userAgent: 'vitest',
+    });
+    expect(accepted.status).toBe('ok');
+    expect(accepted.user.email).toBe('founder@example.com');
+    expect(accepted.session.mfa_required).toBe(false);
+    expect(accepted.refresh_token).toHaveLength(64);
+
+    const consumedToken = await getEmailToken(env, invite.token, 'signup');
+    expect(consumedToken).toBeNull();
+
+    const defaultCanvases = await listCanvases(env, userId);
+    expect(defaultCanvases).toHaveLength(1);
+    const defaultCanvas = defaultCanvases[0];
+    expect(defaultCanvas.title).toBe('Lean Canvas Quickstart');
+
+    const versionsBefore = await listCanvasVersions(env, userId, defaultCanvas.id);
+    expect(versionsBefore).toHaveLength(1);
+    expect(versionsBefore[0].revision).toBe(1);
+
+    const updatedCanvas = await saveCanvas(env, userId, defaultCanvas.id, {
+      title: 'Pitch Canvas',
+      summary: 'Refined lean canvas for funding prep',
+      content: { problem: ['Capital access'], solution: ['Dedicated concierge'] },
+      revision: versionsBefore[0].revision,
+    });
+    expect(updatedCanvas.title).toBe('Pitch Canvas');
+    expect(updatedCanvas.status).toBe('active');
+
+    await expect(
+      saveCanvas(env, userId, defaultCanvas.id, {
+        title: 'Conflicting update',
+        revision: 0,
+      })
+    ).rejects.toThrow('revision_conflict');
+
+    const archived = await saveCanvas(env, userId, defaultCanvas.id, {
+      status: 'archived',
+      content: { archived: true },
+    });
+    expect(archived.status).toBe('archived');
+
+    const versionsAfter = await listCanvasVersions(env, userId, defaultCanvas.id);
+    expect(versionsAfter).toHaveLength(3);
+    const latest = versionsAfter.find((entry) => entry.revision === 3);
+    expect(latest).toBeDefined();
+    const prior = versionsAfter.find((entry) => entry.revision === 2);
+    expect(((prior?.diff ?? {}) as Record<string, unknown>).base_revision).toBe(1);
+
+    const newCanvas = await createCanvas(env, userId, {
+      title: 'Expansion Plan',
+      summary: 'Internal planning document',
+      content: { keyMetrics: ['MRR', 'Activation time'] },
+      status: 'active',
+    });
+    expect(newCanvas.title).toBe('Expansion Plan');
+
+    const passwordLogin = await login(env, {
+      email: 'founder@example.com',
+      password: 'Sup3rSecure!PW',
+      ip: '198.51.100.2',
+      userAgent: 'vitest',
+    });
+    expect(passwordLogin.status).toBe('ok');
+
+    const enrollment = await startTotpEnrollment(env, userId);
+    const totp = new TOTP({ issuer: 'fungiagricap', label: 'founder@example.com', secret: enrollment.secret });
+    const totpCode = totp.generate();
+    const confirmedProfile = await confirmTotpEnrollment(env, {
+      userId,
+      methodId: enrollment.method_id,
+      code: totpCode,
+    });
+    expect(confirmedProfile.mfa_enrolled).toBe(true);
+
+    const challenge = await login(env, {
+      email: 'founder@example.com',
+      password: 'Sup3rSecure!PW',
+    });
+    expect(challenge.status).toBe('mfa-required');
+    if (challenge.status !== 'mfa-required') {
+      throw new Error('expected mfa challenge');
+    }
+    const activeChallenge = challenge;
+    const challengeTokenRecord = await getEmailToken(env, activeChallenge.challenge_id, 'mfa-challenge');
+    expect(challengeTokenRecord).not.toBeNull();
+
+    const secondCode = totp.generate();
+    const mfaSession = await verifyMfaChallenge(env, {
+      challengeId: activeChallenge.challenge_id,
+      code: secondCode,
+      ip: '203.0.113.11',
+      userAgent: 'vitest-mfa',
+    });
+    expect(mfaSession.status).toBe('ok');
+    expect(mfaSession.user.mfa_enrolled).toBe(true);
+
+    const consumedChallenge = await getEmailToken(env, activeChallenge.challenge_id, 'mfa-challenge');
+    expect(consumedChallenge).toBeNull();
+
+    const expiring = await createEmailToken(env, {
+      purpose: 'mfa-challenge',
+      userId,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(await getEmailToken(env, expiring.token, 'mfa-challenge')).not.toBeNull();
+    await env.DB.prepare('UPDATE email_tokens SET expires_at = ?1 WHERE id = ?2')
+      .bind(new Date(Date.now() - 60_000).toISOString(), expiring.id)
+      .run();
+    expect(await getEmailToken(env, expiring.token, 'mfa-challenge')).toBeNull();
+
+    const refreshed = await refreshSession(env, {
+      sessionId: mfaSession.session.id,
+      refreshToken: mfaSession.refresh_token,
+      ip: '203.0.113.12',
+      userAgent: 'vitest-refresh',
+    });
+    expect(refreshed.status).toBe('ok');
+    expect(refreshed.refresh_token).not.toBe(mfaSession.refresh_token);
+    expect(refreshed.session.id).toBe(mfaSession.session.id);
+
+    const storedBeforeInvalid = await env.DB.prepare(
+      'SELECT refresh_token_hash, refresh_expires_at FROM sessions WHERE id = ?1'
+    )
+      .bind(refreshed.session.id)
+      .first<{ refresh_token_hash: string; refresh_expires_at: string }>();
+    expect(typeof storedBeforeInvalid?.refresh_token_hash).toBe('string');
+    expect(Date.parse(storedBeforeInvalid?.refresh_expires_at ?? '')).toBeGreaterThan(Date.now());
+
+    await expect(
+      refreshSession(env, {
+        sessionId: mfaSession.session.id,
+        refreshToken: mfaSession.refresh_token,
+      })
+    ).rejects.toThrow();
+
+    const storedSession = await env.DB.prepare('SELECT refresh_token_hash, refresh_expires_at FROM sessions WHERE id = ?1')
+      .bind(refreshed.session.id)
+      .first<{ refresh_token_hash: string; refresh_expires_at: string }>();
+    expect(storedSession).toBeNull();
+  });
+});
+
+describe('email templates', () => {
+  it('produces admin decision emails with actionable links', () => {
+    const payload = buildDecisionEmail({
+      recipient: 'admin@example.com',
+      token: 'decision_abc',
+      decisionBaseUrl: 'https://program.fungiagricap.com/admin/account/decision',
+    });
+    expect(payload.subject).toContain('canvas access request');
+    expect(payload.html).toContain('decision_abc');
+  });
+});


### PR DESCRIPTION
## Summary
- add an authentication service layer to handle invite acceptance, login, MFA verification, and session refresh helpers
- harden onboarding storage with refresh token expirations, canvas schema validation, and signup email templates
- document account and canvas runbooks and add end-to-end tests covering approval through MFA enrolment and session rotation

## Testing
- bun test
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc75c83f3483278f9f6a36e236ec93