### PR TITLE
Add Sprint 5 rollout validation plan and tooling

### DIFF
--- a/apps/api/src/security/auth.ts
+++ b/apps/api/src/security/auth.ts
@@ -281,7 +281,7 @@ export async function login(
         methods: ['totp'],
       };
     }
-    if (!verifyTotpToken(verifiedTotp.secret, params.totpCode)) {
+    if (!verifiedTotp.secret || !verifyTotpToken(verifiedTotp.secret, params.totpCode)) {
       throw new Error('invalid_mfa');
     }
   }

--- a/docs/mvp-launch-checklist.md
+++ b/docs/mvp-launch-checklist.md
@@ -31,8 +31,10 @@ This checklist synthesizes the repo's design docs into an ordered plan to take t
 
 ## 5. Enrichment, coverage, and observability
 - Ensure NAICS enrichment via `enrichNaics` is wired to Cloudflare KV fallback behaviour so programs carry industry codes even when remote lookups are missing.
-- Populate coverage metrics (`/v1/sources`, `/v1/stats/coverage`) using the new observability tables; validate freshness windows (≤6h for 4h sources, ≤30h for daily) and NAICS density calculations.
+- Populate coverage metrics (`/v1/sources`, `/v1/stats/coverage`) using the new observability tables.
 - Confirm `ingestion_runs` and `program_diffs` are being written each cycle and that partial/error runs still log diagnostics for debugging.
+- Track NAICS density and tag coverage targets (≥90% of programs with at least one NAICS code, ≥95% with tags) through `/v1/stats/coverage` and alert on regressions.
+- Build or update dashboards that surface ingestion run counts, last-success timestamps, NAICS density trends, and stale-source thresholds for ops readiness.
 
 ## 6. Automated testing & CI
 - Maintain unit tests for NAICS enrichment, catalog dispatch, and query builders alongside Bun type checking to keep CI green.
@@ -47,5 +49,10 @@ This checklist synthesizes the repo's design docs into an ordered plan to take t
 
 ## 8. Post-deploy validation & rollout
 - Execute the rollout plan: apply schema migrations locally first, enable the catalog-driven ingestion loop behind a feature flag or staged cron, and monitor observability dashboards for healthy runs.
+- Run `bun run postdeploy:validate --base-url=https://programs.api.example.com` (override the URL as needed) after each deploy to confirm:
+  - `/v1/sources` freshness adheres to SLA windows (≤6h for `4h` sources, ≤30h for `daily`).
+  - `/v1/stats/coverage` NAICS density remains ≥90% and tag coverage stays on target.
+  - Coverage report history trends are being persisted for dashboards.
 - Validate `/v1/sources` and `/v1/stats/coverage` payloads for completeness, ensuring new fields do not break downstream consumers.
+- Review the [progressive rollout plan](./progressive-rollout-plan.md) before adding new jurisdictions; confirm data quality exit criteria (freshness, NAICS/tag density, alert coverage) are met for each cohort.
 - Once stable, expand the catalog to additional jurisdictions while tracking success criteria (all sources ingest within SLA, coverage endpoints accurate, automation passing).

--- a/docs/progressive-rollout-plan.md
+++ b/docs/progressive-rollout-plan.md
@@ -1,0 +1,50 @@
+# Progressive Rollout Plan for Jurisdiction Expansion
+
+This plan guides how to extend the live source catalog beyond the initial US federal and Ontario feeds. It groups jurisdictions into cohorts, defines validation checkpoints, and links operational guardrails to maintain ingestion quality as coverage grows.
+
+## Objectives
+- Expand coverage methodically across additional U.S. states and Canadian provinces/territories.
+- Preserve ingestion SLAs and NAICS/tag density targets during each rollout wave.
+- Provide clear exit criteria before promoting a cohort from staging to production traffic.
+
+## Cohort sequencing
+1. **Cohort A – High-volume U.S. states**
+   - Target: California, New York, Texas.
+   - Requirements: adapter readiness with rate limiting, fixture-backed dry runs, double-ingest comparison against legacy fixtures.
+2. **Cohort B – Remaining U.S. states**
+   - Sequence in batches of 5–7 states grouped by data portal similarity.
+   - Requirements: ensure credential or API key workflows are documented before enabling scheduled ingestion.
+3. **Cohort C – Canadian provinces and territories**
+   - Prioritise British Columbia and Québec, followed by prairie provinces and Atlantic regions.
+   - Requirements: bilingual content handling verified in enrichment, and CKAN-based feeds tuned for pagination.
+
+Each cohort should be gated behind environment flags (`INGEST_SOURCES_ALLOWLIST`) so they can be enabled per environment.
+
+## Exit criteria per cohort
+- **Ingestion freshness**: 100% of cohort sources have `last_success_at` within SLA (≤6h for `4h`, ≤30h for `daily`) over a rolling 72-hour window.
+- **Run stability**: 7-day success rate ≥85% and no more than one consecutive `partial` or `error` status per source.
+- **Coverage quality**: `/v1/stats/coverage` reports ≥90% NAICS density and ≥95% tag coverage for programs originating from the cohort jurisdictions.
+- **Diff monitoring**: Critical diffs reviewed and signed off in the runbook for at least two consecutive successful runs.
+- **Alerting**: Error rate (>20%) and stale source (>24h) alerts configured with on-call playbooks acknowledging test pages in staging.
+
+## Operational guardrails
+- **Dry-run ingestion**: Run `bun run ingest:once --source=<id>` against staged fixtures before enabling cron. Ensure failure modes are documented in the source adapter README.
+- **Staged cron rollout**: Enable new sources via staggered cron entries (e.g., every 30 minutes offset per source) to avoid burst load while monitoring metrics.
+- **Snapshot retention**: Apply a 90-day retention policy to R2 snapshots using the cleanup script (see below) before scaling cohorts.
+- **Rollback strategy**: Maintain feature flags to disable problematic sources quickly and provide a procedure to replay the most recent good snapshot.
+
+## Dashboard and alert readiness
+- `/v1/sources` freshness heatmap grouped by jurisdiction with stale (>SLA) highlighting.
+- `/v1/stats/coverage` trend chart showing NAICS density and tag coverage for the last 14 days, broken out by cohort tags.
+- Ingestion run timeline with error-rate overlay and annotations for rollout milestones.
+- Alert routing that pages ops when error-rate or stale-source thresholds are exceeded, with Slack notifications for NAICS density dips below 90%.
+
+## Automation hooks
+- **Post-deploy validation**: `bun run postdeploy:validate --base-url=<environment-url>` captures SLA adherence and coverage metrics; archive JSON outputs per deploy.
+- **Snapshot cleanup**: Schedule `bun run scripts/ops.snapshot.ts` (or the dedicated cleanup task when available) weekly to enforce the 90-day retention window.
+- **Diff reviews**: Pipe `program_diffs` marked `critical` into the review workflow and document approval in the cohort rollout checklist.
+
+## Documentation & handoff
+- Update the Cloudflare credentials and DNS override docs as new domains or namespaces are introduced for jurisdiction-specific workers.
+- Record Durable Object or KV provisioning deltas that differ from the baseline setup scripts.
+- Maintain a living checklist in the runbook linking to fixture data, adapter owners, and rollout status for each jurisdiction.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "typecheck": "bunx tsc -p tsconfig.json",
     "lint": "bun run typecheck",
     "openapi": "bun run scripts/generate-openapi.ts",
-    "ingest:once": "bun run scripts/ingest-once.ts"
+    "ingest:once": "bun run scripts/ingest-once.ts",
+    "postdeploy:validate": "bun run scripts/postdeploy.validate.ts"
   },
   "dependencies": {
     "@cloudflare/d1": "^1.4.1",

--- a/scripts/postdeploy.validate.ts
+++ b/scripts/postdeploy.validate.ts
@@ -1,0 +1,268 @@
+import { SOURCES } from '../data/sources/phase2';
+
+type Schedule = '4h' | 'daily';
+
+type CliOptions = {
+  baseUrl: string;
+  output?: string;
+};
+
+type SourcePayload = {
+  id: string;
+  source_id: number;
+  authority: string;
+  jurisdiction_code: string;
+  schedule: Schedule | null;
+  last_success_at: number | null;
+  success_rate_7d: number;
+};
+
+type SourcesResponse = {
+  data: SourcePayload[];
+};
+
+type CoverageReport = {
+  day: string;
+  created_at: number;
+  tagCoverage: { withTags: number; withoutTags: number };
+  naicsCoverage: { withNaics: number; missingNaics: number };
+  validationIssues: Array<{ issue: string; count: number }>;
+};
+
+type CoverageResponse = {
+  naics_density: number;
+  tagCoverage: { withTags: number; withoutTags: number };
+  reports: CoverageReport[];
+  validationIssues: Array<{ issue: string; count: number }>;
+};
+
+type SourceSummary = {
+  id: string;
+  jurisdiction: string;
+  schedule: Schedule | null;
+  lastSuccessAt: number | null;
+  ageMinutes: number | null;
+  withinSla: boolean;
+  status: 'ok' | 'warning' | 'critical';
+  successRate7d: number;
+};
+
+type ValidationSummary = {
+  generatedAt: string;
+  baseUrl: string;
+  ingestion: {
+    totalSources: number;
+    withinSla: number;
+    warning: number;
+    critical: number;
+    staleBeyond24h: number;
+    summaries: SourceSummary[];
+  };
+  coverage: {
+    naicsDensity: number;
+    tagCoverage: { withTags: number; withoutTags: number };
+    latestReport: CoverageReport | null;
+    previousReport: CoverageReport | null;
+    naicsDensityChange: number | null;
+    tagCoverageChange: number | null;
+    validationIssues: Array<{ issue: string; count: number }>;
+  };
+};
+
+const SLA_WINDOWS: Record<Schedule, number> = {
+  '4h': 6 * 60 * 60 * 1000,
+  daily: 30 * 60 * 60 * 1000
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    baseUrl: 'http://127.0.0.1:8787'
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token) continue;
+    if (token.startsWith('--base-url=')) {
+      options.baseUrl = token.split('=')[1] ?? options.baseUrl;
+      continue;
+    }
+    if (token === '--base-url' && argv[i + 1]) {
+      options.baseUrl = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (token.startsWith('--output=')) {
+      options.output = token.split('=')[1];
+      continue;
+    }
+    if (token === '--output' && argv[i + 1]) {
+      options.output = argv[i + 1];
+      i += 1;
+      continue;
+    }
+  }
+  return options;
+}
+
+async function fetchJson<T>(baseUrl: string, path: string): Promise<T> {
+  const url = new URL(path, baseUrl);
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Request to ${url.toString()} failed (${response.status}): ${body}`);
+  }
+  return (await response.json()) as T;
+}
+
+function computeSourceSummary(source: SourcePayload, now: number): SourceSummary {
+  const def = SOURCES.find((candidate) => candidate.id === source.id);
+  const schedule: Schedule | null = source.schedule ?? (def?.schedule ?? null);
+  const lastSuccessAt = typeof source.last_success_at === 'number' ? source.last_success_at : null;
+  const threshold = schedule ? SLA_WINDOWS[schedule] : null;
+  const age = lastSuccessAt ? now - lastSuccessAt : null;
+  const withinSla = threshold !== null && age !== null ? age <= threshold : false;
+  const staleBeyond24h = age !== null ? age > DAY_MS : true;
+
+  let status: SourceSummary['status'] = 'ok';
+  if (!withinSla) {
+    status = staleBeyond24h ? 'critical' : 'warning';
+  }
+
+  return {
+    id: source.id,
+    jurisdiction: source.jurisdiction_code,
+    schedule,
+    lastSuccessAt,
+    ageMinutes: age !== null ? Math.round(age / 60000) : null,
+    withinSla,
+    status,
+    successRate7d: source.success_rate_7d
+  };
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function buildSummary(
+  sourcesResponse: SourcesResponse,
+  coverageResponse: CoverageResponse,
+  options: CliOptions,
+  now: number
+): ValidationSummary {
+  const summaries = sourcesResponse.data.map((source) => computeSourceSummary(source, now));
+  const withinSla = summaries.filter((summary) => summary.withinSla).length;
+  const warning = summaries.filter((summary) => summary.status === 'warning').length;
+  const critical = summaries.filter((summary) => summary.status === 'critical').length;
+  const staleBeyond24h = summaries.filter((summary) => {
+    if (summary.ageMinutes === null) return true;
+    return summary.ageMinutes > (DAY_MS / 60000);
+  }).length;
+
+  const reports = coverageResponse.reports ?? [];
+  const latestReport = reports[0] ?? null;
+  const previousReport = reports[1] ?? null;
+  const naicsDensityChange =
+    latestReport && previousReport
+      ? (latestReport.naicsCoverage.withNaics / Math.max(latestReport.naicsCoverage.withNaics + latestReport.naicsCoverage.missingNaics, 1)) -
+        (previousReport.naicsCoverage.withNaics /
+          Math.max(previousReport.naicsCoverage.withNaics + previousReport.naicsCoverage.missingNaics, 1))
+      : null;
+  const tagCoverageChange =
+    latestReport && previousReport
+      ? (latestReport.tagCoverage.withTags / Math.max(latestReport.tagCoverage.withTags + latestReport.tagCoverage.withoutTags, 1)) -
+        (previousReport.tagCoverage.withTags /
+          Math.max(previousReport.tagCoverage.withTags + previousReport.tagCoverage.withoutTags, 1))
+      : null;
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    baseUrl: options.baseUrl,
+    ingestion: {
+      totalSources: summaries.length,
+      withinSla,
+      warning,
+      critical,
+      staleBeyond24h,
+      summaries
+    },
+    coverage: {
+      naicsDensity: coverageResponse.naics_density,
+      tagCoverage: coverageResponse.tagCoverage,
+      latestReport,
+      previousReport,
+      naicsDensityChange,
+      tagCoverageChange,
+      validationIssues: coverageResponse.validationIssues ?? []
+    }
+  };
+}
+
+function logSummary(summary: ValidationSummary) {
+  console.log(`Post-deploy validation for ${summary.baseUrl}`);
+  console.log('Ingestion SLA adherence:');
+  console.log(
+    `  ${summary.ingestion.withinSla}/${summary.ingestion.totalSources} sources within SLA ` +
+      `(warning=${summary.ingestion.warning}, critical=${summary.ingestion.critical})`
+  );
+  if (summary.ingestion.summaries.length > 0) {
+    const worstOffenders = summary.ingestion.summaries
+      .filter((summaryEntry) => summaryEntry.status !== 'ok')
+      .sort((a, b) => (b.ageMinutes ?? 0) - (a.ageMinutes ?? 0))
+      .slice(0, 5);
+    if (worstOffenders.length > 0) {
+      console.log('  Stale sources:');
+      for (const offender of worstOffenders) {
+        const age = offender.ageMinutes !== null ? `${offender.ageMinutes}m` : 'unknown';
+        console.log(`    - ${offender.id} (${offender.jurisdiction}) – age ${age}, status ${offender.status}`);
+      }
+    }
+  }
+
+  const naicsPercent = formatPercent(summary.coverage.naicsDensity);
+  const tagPercent = (() => {
+    const { withTags, withoutTags } = summary.coverage.tagCoverage;
+    const total = withTags + withoutTags;
+    return total > 0 ? formatPercent(withTags / total) : '0.0%';
+  })();
+  console.log('Coverage metrics:');
+  console.log(`  NAICS density: ${naicsPercent}`);
+  console.log(`  Tag coverage: ${tagPercent}`);
+  if (summary.coverage.naicsDensityChange !== null) {
+    const change = formatPercent(summary.coverage.naicsDensityChange);
+    console.log(`  NAICS density change vs. previous report: ${change}`);
+  }
+  if (summary.coverage.tagCoverageChange !== null) {
+    const change = formatPercent(summary.coverage.tagCoverageChange);
+    console.log(`  Tag coverage change vs. previous report: ${change}`);
+  }
+  if (summary.coverage.validationIssues.length > 0) {
+    console.log('  Validation issues:');
+    for (const issue of summary.coverage.validationIssues.slice(0, 5)) {
+      console.log(`    - ${issue.issue} (count=${issue.count})`);
+    }
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  const now = Date.now();
+  const sources = await fetchJson<SourcesResponse>(options.baseUrl, '/v1/sources');
+  const coverage = await fetchJson<CoverageResponse>(options.baseUrl, '/v1/stats/coverage');
+  const summary = buildSummary(sources, coverage, options, now);
+  logSummary(summary);
+  if (options.output) {
+    await Bun.write(options.output, JSON.stringify(summary, null, 2));
+    console.log(`Summary written to ${options.output}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/postdeploy.validate.ts
+++ b/scripts/postdeploy.validate.ts
@@ -94,7 +94,10 @@ function parseArgs(argv: string[]): CliOptions {
       continue;
     }
     if (token.startsWith('--output=')) {
-      options.output = token.split('=')[1];
+      const outputValue = token.split('=')[1];
+      if (outputValue !== undefined && outputValue !== '') {
+        options.output = outputValue;
+      }
       continue;
     }
     if (token === '--output' && argv[i + 1]) {

--- a/scripts/postdeploy.validate.ts
+++ b/scripts/postdeploy.validate.ts
@@ -84,7 +84,8 @@ function parseArgs(argv: string[]): CliOptions {
     const token = argv[i];
     if (!token) continue;
     if (token.startsWith('--base-url=')) {
-      options.baseUrl = token.split('=')[1] ?? options.baseUrl;
+      const baseUrlValue = token.split('=')[1];
+      options.baseUrl = baseUrlValue && baseUrlValue.trim() !== '' ? baseUrlValue : options.baseUrl;
       continue;
     }
     if (token === '--base-url' && argv[i + 1]) {


### PR DESCRIPTION
## Summary
- document the jurisdiction expansion rollout plan with updated launch checklist and observability guardrails
- add a post-deploy validation script and package entry to audit `/v1/sources` freshness and coverage trends
- harden MFA verification by checking for a missing secret before validating TOTP tokens

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc903564148327a2eb8ebd10014469